### PR TITLE
Ability to label signals in the group

### DIFF
--- a/signal/group.go
+++ b/signal/group.go
@@ -145,3 +145,11 @@ func (g *Group) WithErr(err error) *Group {
 func (g *Group) Len() int {
 	return len(g.signals)
 }
+
+// WithSignalLabels sets labels on each signal within the group and returns it
+func (g *Group) WithSignalLabels(labels common.LabelsCollection) *Group {
+	for _, p := range g.SignalsOrNil() {
+		p.WithLabels(labels)
+	}
+	return g
+}

--- a/signal/group_test.go
+++ b/signal/group_test.go
@@ -2,9 +2,11 @@ package signal
 
 import (
 	"errors"
+	"testing"
+
+	"github.com/hovsep/fmesh/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestNewGroup(t *testing.T) {
@@ -328,6 +330,23 @@ func TestGroup_Signals(t *testing.T) {
 			group:           NewGroup(1, 2, 3).WithErr(errors.New("some error in chain")),
 			want:            nil,
 			wantErrorString: "some error in chain",
+		},
+		{
+			name: "with labeled signals",
+			group: NewGroup(1, nil, 3).WithSignalLabels(common.LabelsCollection{
+				"flavor": "banana",
+			}),
+			want: Signals{
+				New(1).WithLabels(common.LabelsCollection{
+					"flavor": "banana",
+				}),
+				New(nil).WithLabels(common.LabelsCollection{
+					"flavor": "banana",
+				}),
+				New(3).WithLabels(common.LabelsCollection{
+					"flavor": "banana",
+				})},
+			wantErrorString: "",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Now you can set labels to each signal in the group like this:

```go
signal.NewGroup(payloads...).WithSignalLabels(common.LabelsCollection{
			labelTo: labelUSB,
		})
```