### PR TITLE
Do not allow adding   components with the same name

### DIFF
--- a/component/collection.go
+++ b/component/collection.go
@@ -44,6 +44,11 @@ func (c *Collection) Add(components ...*Component) *Collection {
 	}
 
 	for _, component := range components {
+		if c.AnyMatch(func(existingComponent *Component) bool {
+			return existingComponent.Name() == component.Name()
+		}) {
+			return c.WithChainableErr(fmt.Errorf("component with name '%s' already exists", component.Name()))
+		}
 		c.components[component.Name()] = component
 
 		if component.HasChainableErr() {

--- a/component/collection_test.go
+++ b/component/collection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCollection_ByName(t *testing.T) {
@@ -41,7 +42,7 @@ func TestCollection_ByName(t *testing.T) {
 	}
 }
 
-func TestCollection_With(t *testing.T) {
+func TestCollection_Add(t *testing.T) {
 	tests := []struct {
 		name       string
 		collection *Collection
@@ -67,6 +68,17 @@ func TestCollection_With(t *testing.T) {
 				assert.Equal(t, "existing", collection.ByName("existing").Name())
 				assert.Equal(t, "c1", collection.ByName("c1").Name())
 				assert.Equal(t, "c2", collection.ByName("c2").Name())
+			},
+		},
+		{
+			name:       "adding 2 components with the same name",
+			collection: NewCollection().Add(New("existing")),
+			components: []*Component{New("existing")},
+			assertions: func(t *testing.T, collection *Collection) {
+				require.Error(t, collection.ChainableErr())
+				require.ErrorContains(t, collection.ChainableErr(), "component with name 'existing' already exists")
+				assert.True(t, collection.HasChainableErr())
+				assert.Equal(t, 0, collection.Len())
 			},
 		},
 	}

--- a/fmesh.go
+++ b/fmesh.go
@@ -83,8 +83,15 @@ func (fm *FMesh) AddComponents(components ...*component.Component) *FMesh {
 			c = c.WithLogger(fm.Logger())
 		}
 		fm.components = fm.components.Add(c.WithParentMesh(fm))
+
+		// Propagate error from component
 		if c.HasChainableErr() {
 			return fm.WithChainableErr(c.ChainableErr())
+		}
+
+		// Propagate error from component's collection
+		if fm.components.HasChainableErr() {
+			return fm.WithChainableErr(fm.components.ChainableErr())
 		}
 	}
 

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -161,22 +161,19 @@ func TestFMesh_AddComponents(t *testing.T) {
 			},
 		},
 		{
-			name: "components with duplicating name are collapsed",
+			name: "adding components with same names leads to error",
 			fm:   New("fm1"),
 			args: args{
 				components: []*component.Component{
-					component.New("c1").WithDescription("descr1"),
-					component.New("c2").WithDescription("descr2"),
-					component.New("c2").WithDescription("new descr for c2"), // This will overwrite the previous one
-					component.New("c4").WithDescription("descr4"),
+					component.New("c1"),
+					component.New("c1"),
 				},
 			},
 			assertions: func(t *testing.T, fm *FMesh) {
-				assert.Equal(t, 3, fm.Components().Len())
-				assert.NotNil(t, fm.Components().ByName("c1"))
-				assert.NotNil(t, fm.Components().ByName("c2"))
-				assert.NotNil(t, fm.Components().ByName("c4"))
-				assert.Equal(t, "new descr for c2", fm.Components().ByName("c2").Description())
+				assert.Equal(t, 0, fm.Components().Len())
+				require.Error(t, fm.ChainableErr())
+				require.Contains(t, fm.ChainableErr().Error(), "component with name 'c1' already exists")
+				assert.True(t, fm.HasChainableErr())
 			},
 		},
 


### PR DESCRIPTION
This pull request improves error handling and validation when adding components to a collection or mesh. It ensures that duplicate component names are not allowed, and propagates errors appropriately. The tests have also been updated to reflect the new behavior.

**Component addition validation and error propagation:**

* Prevented adding multiple components with the same name to a `Collection` by checking for name collisions and returning a chainable error if a duplicate is found.
* In `FMesh.AddComponents`, added logic to propagate errors from both individual components and the component collection, ensuring that any error (such as a duplicate name) is surfaced at the mesh level.

**Testing improvements:**

* Updated and expanded tests in `collection_test.go` to cover the new duplicate name error case, using `require` for stricter assertions. [[1]](diffhunk://#diff-842d7c38808fe2bfb8a0a951afe2b633641e50185145769f12a35173d837a047R8) [[2]](diffhunk://#diff-842d7c38808fe2bfb8a0a951afe2b633641e50185145769f12a35173d837a047L44-R45) [[3]](diffhunk://#diff-842d7c38808fe2bfb8a0a951afe2b633641e50185145769f12a35173d837a047R73-R83)
* Modified the test in `fmesh_test.go` to expect an error when adding components with duplicate names, instead of allowing overwrites.