### PR TITLE
Enhance Group with new methods and unify error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.cursor

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,40 +2,61 @@ version: "2"
 linters:
   default: none
   enable:
-    - dupl
-    - gochecknoinits
-    - gocritic
-    - gocyclo
-    - gosec
+    # --- correctness ---
+    - errcheck
+    - errorlint
     - govet
     - ineffassign
+    - makezero
+    - nilerr
+    - nilnil
+    - staticcheck
+    - unused
+    - durationcheck
+    - asasalint
+    - copyloopvar
+    - reassign
+    # --- complexity ---
+    - gocyclo
+    # --- style ---
+    - dupl
+    - goconst
+    - gocritic
+    - godot
     - misspell
     - nakedret
-    - prealloc
+    - nolintlint
     - revive
-    - staticcheck
     - unconvert
     - unparam
-    - unused
-    - testifylint
-    - errcheck
-    - goconst
-    - errorlint
-    - nilerr
     - whitespace
-    - godot
-    - nolintlint
-    - makezero
+    - dupword
+    - recvcheck
+    # --- security ---
+    - gosec
+    # --- performance ---
     - perfsprint
+    - prealloc
+    - mirror
+    # --- best practices ---
+    - gochecknoinits
+    - testifylint
+    - usestdlibvars
+    - intrange
+    - modernize
   settings:
+    dupl:
+      threshold: 200
+    gocognit:
+      min-complexity: 15
+    gocyclo:
+      min-complexity: 15
     goconst:
       min-len: 3
       min-occurrences: 3
     gocritic:
       disabled-checks:
         - wrapperFunc
-        - hugeParam
-        - rangeValCopy
         - singleCaseSwitch
         - ifElseChain
       enabled-tags:
@@ -49,22 +70,21 @@ linters:
   exclusions:
     generated: lax
     rules:
-      - linters:
-          - staticcheck
+      # Package-level doc comments are not required on every file.
+      - linters: [staticcheck]
         text: at least one file in a package should have a package comment
-      - linters:
-          - revive
+      - linters: [revive]
         text: should have a package comment
-      - linters:
-          - dupl
-          - gosec
+      # Test files get relaxed rules.
+      - linters: [dupl, gosec]
         path: _test\.go
-      - linters:
-          - revive
-          - unparam
-          - unused
+      - linters: [gocognit]
+        path: _test\.go$
+      - linters: [revive]
         path: _test\.go$
         text: unused-parameter
+      - linters: [unparam, unused]
+        path: _test\.go$
     paths:
       - vendor
       - third_party$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,8 +47,6 @@ linters:
   settings:
     dupl:
       threshold: 200
-    gocognit:
-      min-complexity: 15
     gocyclo:
       min-complexity: 15
     goconst:
@@ -76,10 +74,8 @@ linters:
       - linters: [revive]
         text: should have a package comment
       # Test files get relaxed rules.
-      - linters: [dupl, gosec]
+      - linters: [dupl, gosec, goconst]
         path: _test\.go
-      - linters: [gocognit]
-        path: _test\.go$
       - linters: [revive]
         path: _test\.go$
         text: unused-parameter

--- a/cycle/group.go
+++ b/cycle/group.go
@@ -58,6 +58,22 @@ func (g *Group) ForEach(action func(*Cycle) error) *Group {
 	return g
 }
 
+// ForEachIf applies the action only to cycles that match the predicate.
+func (g *Group) ForEachIf(predicate Predicate, action func(*Cycle) error) *Group {
+	if g.HasChainableErr() {
+		return g
+	}
+	for _, c := range g.cycles {
+		if predicate(c) {
+			if err := action(c); err != nil {
+				g.chainableErr = err
+				return g
+			}
+		}
+	}
+	return g
+}
+
 // withCycles sets cycles.
 func (g *Group) withCycles(cycles Cycles) *Group {
 	g.cycles = cycles

--- a/cycle/group.go
+++ b/cycle/group.go
@@ -123,6 +123,19 @@ func (g *Group) IsEmpty() bool {
 	return g.Len() == 0
 }
 
+// Find returns the first cycle matching the predicate, or nil if none match.
+func (g *Group) Find(predicate Predicate) *Cycle {
+	if g.HasChainableErr() || g.IsEmpty() {
+		return nil
+	}
+	for _, c := range g.cycles {
+		if predicate(c) {
+			return c
+		}
+	}
+	return nil
+}
+
 // First returns the first cycle in the group.
 // Returns nil if the group is empty or has an error.
 func (g *Group) First() *Cycle {

--- a/cycle/group.go
+++ b/cycle/group.go
@@ -208,6 +208,32 @@ func (g *Group) Filter(predicate Predicate) *Group {
 	return filtered
 }
 
+// MapIf is like Map but only applies the mapper to cycles that match the predicate.
+// Non-matching cycles are kept as-is. Nil mapper results are dropped.
+func (g *Group) MapIf(predicate Predicate, mapper Mapper) *Group {
+	if g.HasChainableErr() {
+		return NewGroup().WithChainableErr(g.ChainableErr())
+	}
+	mapped := NewGroup()
+	for _, c := range g.cycles {
+		if predicate(c) {
+			transformedCyc := mapper(c)
+			if transformedCyc != nil {
+				mapped = mapped.Add(transformedCyc)
+				if mapped.HasChainableErr() {
+					return mapped
+				}
+			}
+		} else {
+			mapped = mapped.Add(c)
+			if mapped.HasChainableErr() {
+				return mapped
+			}
+		}
+	}
+	return mapped
+}
+
 // Map returns a new group with cycles transformed by the mapper function.
 func (g *Group) Map(mapper Mapper) *Group {
 	if g.HasChainableErr() {

--- a/cycle/group_test.go
+++ b/cycle/group_test.go
@@ -152,6 +152,62 @@ func TestGroup_ForEach(t *testing.T) {
 	})
 }
 
+func TestGroup_ForEachIf(t *testing.T) {
+	c1 := New().WithNumber(1)
+	c2 := New().WithNumber(2)
+	c3 := New().WithNumber(3)
+	c4 := New().WithNumber(4)
+
+	t.Run("applies action only to matching cycles", func(t *testing.T) {
+		group := NewGroup().Add(c1, c2, c3, c4)
+		count := 0
+		group.ForEachIf(
+			func(c *Cycle) bool { return c.Number()%2 == 0 },
+			func(c *Cycle) error { count++; return nil },
+		)
+		assert.Equal(t, 2, count) // c2 and c4
+	})
+
+	t.Run("applies action to all when predicate always true", func(t *testing.T) {
+		group := NewGroup().Add(c1, c2, c3)
+		count := 0
+		group.ForEachIf(
+			func(c *Cycle) bool { return true },
+			func(c *Cycle) error { count++; return nil },
+		)
+		assert.Equal(t, 3, count)
+	})
+
+	t.Run("applies action to none when predicate always false", func(t *testing.T) {
+		group := NewGroup().Add(c1, c2, c3)
+		count := 0
+		group.ForEachIf(
+			func(c *Cycle) bool { return false },
+			func(c *Cycle) error { count++; return nil },
+		)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("stops on error and sets chainable error", func(t *testing.T) {
+		group := NewGroup().Add(c1, c2, c3)
+		result := group.ForEachIf(
+			func(c *Cycle) bool { return true },
+			func(c *Cycle) error { return assert.AnError },
+		)
+		assert.True(t, result.HasChainableErr())
+	})
+
+	t.Run("skips when group has error", func(t *testing.T) {
+		group := NewGroup().Add(c1).WithChainableErr(assert.AnError)
+		visited := false
+		group.ForEachIf(
+			func(c *Cycle) bool { return true },
+			func(c *Cycle) error { visited = true; return nil },
+		)
+		assert.False(t, visited)
+	})
+}
+
 func TestGroup_Last(t *testing.T) {
 	c1 := New().WithNumber(1)
 	c2 := New().WithNumber(2)

--- a/cycle/group_test.go
+++ b/cycle/group_test.go
@@ -243,6 +243,38 @@ func TestGroup_First(t *testing.T) {
 	})
 }
 
+func TestGroup_Find(t *testing.T) {
+	c1 := New().WithNumber(1)
+	c2 := New().WithNumber(2)
+	c3 := New().WithNumber(3)
+	c4 := New().WithNumber(4)
+
+	t.Run("returns first matching cycle", func(t *testing.T) {
+		group := NewGroup().Add(c1, c2, c3, c4)
+		got := group.Find(func(c *Cycle) bool { return c.Number()%2 == 0 })
+		require.NotNil(t, got)
+		assert.Equal(t, 2, got.Number()) // first even, not all evens
+	})
+
+	t.Run("returns nil when no cycle matches", func(t *testing.T) {
+		group := NewGroup().Add(c1, c3)
+		got := group.Find(func(c *Cycle) bool { return c.Number()%2 == 0 })
+		assert.Nil(t, got)
+	})
+
+	t.Run("returns nil for empty group", func(t *testing.T) {
+		group := NewGroup()
+		got := group.Find(func(c *Cycle) bool { return true })
+		assert.Nil(t, got)
+	})
+
+	t.Run("returns nil when group has error", func(t *testing.T) {
+		group := NewGroup().Add(c1).WithChainableErr(assert.AnError)
+		got := group.Find(func(c *Cycle) bool { return true })
+		assert.Nil(t, got)
+	})
+}
+
 func TestGroup_All(t *testing.T) {
 	c1 := New().WithNumber(1)
 	c2 := New().WithNumber(2)

--- a/cycle/group_test.go
+++ b/cycle/group_test.go
@@ -397,6 +397,58 @@ func TestGroup_Filter(t *testing.T) {
 	})
 }
 
+func TestGroup_MapIf(t *testing.T) {
+	t.Run("maps only matching cycles", func(t *testing.T) {
+		group := NewGroup().Add(New().WithNumber(1), New().WithNumber(2), New().WithNumber(3), New().WithNumber(4))
+		mapped := group.MapIf(
+			func(c *Cycle) bool { return c.Number()%2 == 0 },
+			func(c *Cycle) *Cycle { return c.WithNumber(c.Number() * 100) },
+		)
+		assert.Equal(t, 4, mapped.Len())
+		assert.Equal(t, 1, mapped.First().Number()) // odd unchanged
+		assert.NotNil(t, mapped.Find(func(c *Cycle) bool { return c.Number() == 200 }))
+		assert.NotNil(t, mapped.Find(func(c *Cycle) bool { return c.Number() == 400 }))
+	})
+
+	t.Run("predicate matches none - all cycles kept as-is", func(t *testing.T) {
+		group := NewGroup().Add(New().WithNumber(1), New().WithNumber(2), New().WithNumber(3))
+		mapped := group.MapIf(
+			func(c *Cycle) bool { return false },
+			func(c *Cycle) *Cycle { return c.WithNumber(-1) },
+		)
+		assert.Equal(t, 3, mapped.Len())
+		assert.Equal(t, 1, mapped.First().Number())
+	})
+
+	t.Run("predicate matches all - all cycles mapped", func(t *testing.T) {
+		group := NewGroup().Add(New().WithNumber(1), New().WithNumber(2))
+		mapped := group.MapIf(
+			func(c *Cycle) bool { return true },
+			func(c *Cycle) *Cycle { return c.WithNumber(c.Number() * 10) },
+		)
+		assert.Equal(t, 2, mapped.Len())
+		assert.Equal(t, 10, mapped.First().Number())
+	})
+
+	t.Run("nil mapper result drops the cycle", func(t *testing.T) {
+		group := NewGroup().Add(New().WithNumber(1), New().WithNumber(2), New().WithNumber(3))
+		mapped := group.MapIf(
+			func(c *Cycle) bool { return c.Number() == 2 },
+			func(c *Cycle) *Cycle { return nil },
+		)
+		assert.Equal(t, 2, mapped.Len()) // c2 dropped, c1 and c3 kept
+	})
+
+	t.Run("propagates error from source group", func(t *testing.T) {
+		group := NewGroup().Add(New().WithNumber(1)).WithChainableErr(assert.AnError)
+		mapped := group.MapIf(
+			func(c *Cycle) bool { return true },
+			func(c *Cycle) *Cycle { return c },
+		)
+		assert.True(t, mapped.HasChainableErr())
+	})
+}
+
 func TestGroup_Map(t *testing.T) {
 	c1 := New().WithNumber(1)
 	c2 := New().WithNumber(2)

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -689,7 +689,7 @@ func TestFMesh_Run(t *testing.T) {
 			gotCycles, err := got.Cycles.All()
 			require.NoError(t, err)
 
-			for i := 0; i < got.Cycles.Len(); i++ {
+			for i := range got.Cycles.Len() {
 				wantCycle := wantCycles[i]
 				gotCycle := gotCycles[i]
 				assert.Equal(t, wantCycle.ActivationResults().Len(), gotCycle.ActivationResults().Len(), "ActivationResultCollection len mismatch")

--- a/integration_tests/component_hooks/basic_test.go
+++ b/integration_tests/component_hooks/basic_test.go
@@ -414,7 +414,7 @@ func BenchmarkComponentHooks_Overhead(b *testing.B) {
 		c.InputByName("in").PutSignals(signal.New(1))
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			c.MaybeActivate()
 			c.InputByName("in").PutSignals(signal.New(1))
 		}
@@ -435,7 +435,7 @@ func BenchmarkComponentHooks_Overhead(b *testing.B) {
 		c.InputByName("in").PutSignals(signal.New(1))
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			c.MaybeActivate()
 			c.InputByName("in").PutSignals(signal.New(1))
 		}

--- a/port/group.go
+++ b/port/group.go
@@ -3,8 +3,6 @@ package port
 import (
 	"fmt"
 	"slices"
-
-	"github.com/hovsep/fmesh/labels"
 )
 
 // Group represents a list of ports.
@@ -138,13 +136,6 @@ func (g *Group) Len() int {
 		return 0
 	}
 	return len(g.ports)
-}
-
-// AddLabelsToAll adds labels to each port within the group and returns it.
-func (g *Group) AddLabelsToAll(labelMap labels.Map) *Group {
-	return g.ForEach(func(p *Port) error {
-		return p.AddLabels(labelMap).ChainableErr()
-	})
 }
 
 // IsEmpty returns true when there are no ports in the group.

--- a/port/group.go
+++ b/port/group.go
@@ -220,6 +220,32 @@ func (g *Group) Filter(predicate Predicate) *Group {
 	return filtered
 }
 
+// MapIf is like Map but only applies the mapper to ports that match the predicate.
+// Non-matching ports are kept as-is. Nil mapper results are dropped.
+func (g *Group) MapIf(predicate Predicate, mapper Mapper) *Group {
+	if g.HasChainableErr() {
+		return NewGroup().WithChainableErr(g.ChainableErr())
+	}
+	mapped := NewGroup()
+	for _, p := range g.ports {
+		if predicate(p) {
+			transformedPort := mapper(p)
+			if transformedPort != nil {
+				mapped = mapped.Add(transformedPort)
+				if mapped.HasChainableErr() {
+					return mapped
+				}
+			}
+		} else {
+			mapped = mapped.Add(p)
+			if mapped.HasChainableErr() {
+				return mapped
+			}
+		}
+	}
+	return mapped
+}
+
 // Map returns a new group with ports transformed by the mapper function.
 func (g *Group) Map(mapper Mapper) *Group {
 	if g.HasChainableErr() {

--- a/port/group.go
+++ b/port/group.go
@@ -143,6 +143,19 @@ func (g *Group) IsEmpty() bool {
 	return g.Len() == 0
 }
 
+// Find returns the first port matching the predicate, or nil if none match.
+func (g *Group) Find(predicate Predicate) *Port {
+	if g.HasChainableErr() || g.IsEmpty() {
+		return nil
+	}
+	for _, p := range g.ports {
+		if predicate(p) {
+			return p
+		}
+	}
+	return nil
+}
+
 // First returns the first port in the group.
 // Returns nil if the group is empty or has an error.
 func (g *Group) First() *Port {

--- a/port/group.go
+++ b/port/group.go
@@ -85,6 +85,22 @@ func (g *Group) ForEach(action func(*Port) error) *Group {
 	return g
 }
 
+// ForEachIf applies the action only to ports that match the predicate.
+func (g *Group) ForEachIf(predicate Predicate, action func(*Port) error) *Group {
+	if g.HasChainableErr() {
+		return g
+	}
+	for _, p := range g.ports {
+		if predicate(p) {
+			if err := action(p); err != nil {
+				g.chainableErr = err
+				return g
+			}
+		}
+	}
+	return g
+}
+
 // withPorts sets ports.
 func (g *Group) withPorts(ports Ports) *Group {
 	g.ports = ports

--- a/port/group_test.go
+++ b/port/group_test.go
@@ -347,6 +347,56 @@ func TestGroup_Filter(t *testing.T) {
 	})
 }
 
+func TestGroup_MapIf(t *testing.T) {
+	t.Run("maps only matching ports", func(t *testing.T) {
+		group := NewGroup("p1", "special", "p2")
+		mapped := group.MapIf(
+			func(p *Port) bool { return strings.HasPrefix(p.Name(), "special") },
+			func(p *Port) *Port { return NewOutput("mapped_" + p.Name()) },
+		)
+		assert.Equal(t, 3, mapped.Len())
+		assert.Equal(t, "mapped_special", mapped.Find(func(p *Port) bool {
+			return strings.HasPrefix(p.Name(), "mapped_")
+		}).Name())
+	})
+
+	t.Run("predicate matches none - all ports kept as-is", func(t *testing.T) {
+		group := NewGroup("p1", "p2", "p3")
+		mapped := group.MapIf(
+			func(p *Port) bool { return false },
+			func(p *Port) *Port { return NewOutput("x") },
+		)
+		assert.Equal(t, 3, mapped.Len())
+	})
+
+	t.Run("predicate matches all - all ports mapped", func(t *testing.T) {
+		group := NewGroup("p1", "p2")
+		mapped := group.MapIf(
+			func(p *Port) bool { return true },
+			func(p *Port) *Port { return NewOutput("mapped_" + p.Name()) },
+		)
+		assert.Equal(t, 2, mapped.Len())
+	})
+
+	t.Run("nil mapper result drops the port", func(t *testing.T) {
+		group := NewGroup("p1", "p2", "p3")
+		mapped := group.MapIf(
+			func(p *Port) bool { return p.Name() == "p2" },
+			func(p *Port) *Port { return nil },
+		)
+		assert.Equal(t, 2, mapped.Len()) // p2 dropped, p1 and p3 kept
+	})
+
+	t.Run("propagates error from source group", func(t *testing.T) {
+		group := NewGroup("p1").WithChainableErr(assert.AnError)
+		mapped := group.MapIf(
+			func(p *Port) bool { return true },
+			func(p *Port) *Port { return p },
+		)
+		assert.True(t, mapped.HasChainableErr())
+	})
+}
+
 func TestGroup_Map(t *testing.T) {
 	t.Run("transforms ports", func(t *testing.T) {
 		group := NewGroup("p1", "p2")

--- a/port/group_test.go
+++ b/port/group_test.go
@@ -409,6 +409,37 @@ func TestGroup_First(t *testing.T) {
 	})
 }
 
+func TestGroup_Find(t *testing.T) {
+	t.Run("returns first matching port", func(t *testing.T) {
+		group := NewGroup("p1", "special", "p2")
+		got := group.Find(func(p *Port) bool {
+			return strings.HasPrefix(p.Name(), "special")
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "special", got.Name())
+	})
+
+	t.Run("returns nil when no port matches", func(t *testing.T) {
+		group := NewGroup("p1", "p2", "p3")
+		got := group.Find(func(p *Port) bool {
+			return strings.HasPrefix(p.Name(), "x")
+		})
+		assert.Nil(t, got)
+	})
+
+	t.Run("returns nil for empty group", func(t *testing.T) {
+		group := NewGroup()
+		got := group.Find(func(p *Port) bool { return true })
+		assert.Nil(t, got)
+	})
+
+	t.Run("returns nil when group has error", func(t *testing.T) {
+		group := NewGroup("p1").WithChainableErr(assert.AnError)
+		got := group.Find(func(p *Port) bool { return true })
+		assert.Nil(t, got)
+	})
+}
+
 func TestGroup_FirstDoesNotPoisonGroup(t *testing.T) {
 	t.Run("First does not poison group when empty", func(t *testing.T) {
 		group := NewGroup()

--- a/port/group_test.go
+++ b/port/group_test.go
@@ -1,6 +1,7 @@
 package port
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -195,6 +196,57 @@ func TestGroup_ForEach(t *testing.T) {
 			visited = true
 			return nil
 		})
+		assert.False(t, visited)
+	})
+}
+
+func TestGroup_ForEachIf(t *testing.T) {
+	t.Run("applies action only to matching ports", func(t *testing.T) {
+		group := NewGroup("p1", "p2", "special1", "special2")
+		count := 0
+		group.ForEachIf(
+			func(p *Port) bool { return strings.HasPrefix(p.Name(), "special") },
+			func(p *Port) error { count++; return nil },
+		)
+		assert.Equal(t, 2, count)
+	})
+
+	t.Run("applies action to all when predicate always true", func(t *testing.T) {
+		group := NewGroup("p1", "p2", "p3")
+		count := 0
+		group.ForEachIf(
+			func(p *Port) bool { return true },
+			func(p *Port) error { count++; return nil },
+		)
+		assert.Equal(t, 3, count)
+	})
+
+	t.Run("applies action to none when predicate always false", func(t *testing.T) {
+		group := NewGroup("p1", "p2", "p3")
+		count := 0
+		group.ForEachIf(
+			func(p *Port) bool { return false },
+			func(p *Port) error { count++; return nil },
+		)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("stops on error and sets chainable error", func(t *testing.T) {
+		group := NewGroup("p1", "p2", "p3")
+		result := group.ForEachIf(
+			func(p *Port) bool { return true },
+			func(p *Port) error { return assert.AnError },
+		)
+		assert.True(t, result.HasChainableErr())
+	})
+
+	t.Run("skips when group has error", func(t *testing.T) {
+		group := NewGroup("p1").WithChainableErr(assert.AnError)
+		visited := false
+		group.ForEachIf(
+			func(p *Port) bool { return true },
+			func(p *Port) error { visited = true; return nil },
+		)
 		assert.False(t, visited)
 	})
 }

--- a/signal/group.go
+++ b/signal/group.go
@@ -268,6 +268,22 @@ func (g *Group) ForEach(action func(*Signal) error) *Group {
 	return g
 }
 
+// ForEachIf applies the action only to signals that match the predicate.
+func (g *Group) ForEachIf(predicate Predicate, action func(*Signal) error) *Group {
+	if g.HasChainableErr() {
+		return g
+	}
+	for _, s := range g.signals {
+		if predicate(s) {
+			if err := action(s); err != nil {
+				g.chainableErr = err
+				return g
+			}
+		}
+	}
+	return g
+}
+
 // Filter returns a new group with signals that pass the filter.
 func (g *Group) Filter(p Predicate) *Group {
 	if g.HasChainableErr() {

--- a/signal/group.go
+++ b/signal/group.go
@@ -40,6 +40,19 @@ func (g *Group) IsEmpty() bool {
 	return g.Len() == 0
 }
 
+// Find returns the first signal matching the predicate, or nil if none match.
+func (g *Group) Find(predicate Predicate) *Signal {
+	if g.HasChainableErr() || g.IsEmpty() {
+		return nil
+	}
+	for _, s := range g.signals {
+		if predicate(s) {
+			return s
+		}
+	}
+	return nil
+}
+
 // AnyMatch returns true if at least one signal matches the predicate.
 func (g *Group) AnyMatch(p Predicate) bool {
 	if g.HasChainableErr() {

--- a/signal/group.go
+++ b/signal/group.go
@@ -300,6 +300,22 @@ func (g *Group) Map(m Mapper) *Group {
 	return NewGroup().withSignals(mappedSignals)
 }
 
+// MapIf is like Map but only applies the mapper function to signals that match the predicate.
+func (g *Group) MapIf(predicate Predicate, mapper Mapper) *Group {
+	if g.HasChainableErr() {
+		return g
+	}
+	mapped := make(Signals, len(g.signals))
+	for i, s := range g.signals {
+		if predicate(s) {
+			mapped[i] = s.Map(mapper)
+		} else {
+			mapped[i] = s
+		}
+	}
+	return NewGroup().withSignals(mapped)
+}
+
 // MapPayloads returns a new group with payloads transformed by the mapper function.
 func (g *Group) MapPayloads(mapper PayloadMapper) *Group {
 	if g.HasChainableErr() {

--- a/signal/group.go
+++ b/signal/group.go
@@ -185,8 +185,7 @@ func (g *Group) Add(signals ...*Signal) *Group {
 // Without removes signals matching the predicate and returns a new group.
 func (g *Group) Without(predicate Predicate) *Group {
 	if g.HasChainableErr() {
-		// Do nothing but propagate the error
-		return g
+		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
 	// Keep signals that DON'T match the predicate
 	return g.Filter(func(s *Signal) bool {
@@ -300,8 +299,7 @@ func (g *Group) ForEachIf(predicate Predicate, action func(*Signal) error) *Grou
 // Filter returns a new group with signals that pass the filter.
 func (g *Group) Filter(p Predicate) *Group {
 	if g.HasChainableErr() {
-		// Do nothing but propagate the error
-		return g
+		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
 
 	filteredSignals := make(Signals, 0)
@@ -317,8 +315,7 @@ func (g *Group) Filter(p Predicate) *Group {
 // Map returns a new group with signals transformed by the mapper function.
 func (g *Group) Map(m Mapper) *Group {
 	if g.HasChainableErr() {
-		// Do nothing but propagate the error
-		return g
+		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
 
 	mappedSignals := make(Signals, 0)
@@ -332,7 +329,7 @@ func (g *Group) Map(m Mapper) *Group {
 // MapIf is like Map but only applies the mapper function to signals that match the predicate.
 func (g *Group) MapIf(predicate Predicate, mapper Mapper) *Group {
 	if g.HasChainableErr() {
-		return g
+		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
 	mapped := make(Signals, len(g.signals))
 	for i, s := range g.signals {
@@ -348,7 +345,7 @@ func (g *Group) MapIf(predicate Predicate, mapper Mapper) *Group {
 // MapPayloadsIf is like MapPayloads but only applies the mapper to signals that match the predicate.
 func (g *Group) MapPayloadsIf(predicate Predicate, mapper PayloadMapper) *Group {
 	if g.HasChainableErr() {
-		return g
+		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
 	mapped := make(Signals, len(g.signals))
 	for i, s := range g.signals {
@@ -364,8 +361,7 @@ func (g *Group) MapPayloadsIf(predicate Predicate, mapper PayloadMapper) *Group 
 // MapPayloads returns a new group with payloads transformed by the mapper function.
 func (g *Group) MapPayloads(mapper PayloadMapper) *Group {
 	if g.HasChainableErr() {
-		// Do nothing but propagate the error
-		return g
+		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
 
 	mappedSignals := make(Signals, 0)

--- a/signal/group.go
+++ b/signal/group.go
@@ -316,6 +316,22 @@ func (g *Group) MapIf(predicate Predicate, mapper Mapper) *Group {
 	return NewGroup().withSignals(mapped)
 }
 
+// MapPayloadsIf is like MapPayloads but only applies the mapper to signals that match the predicate.
+func (g *Group) MapPayloadsIf(predicate Predicate, mapper PayloadMapper) *Group {
+	if g.HasChainableErr() {
+		return g
+	}
+	mapped := make(Signals, len(g.signals))
+	for i, s := range g.signals {
+		if predicate(s) {
+			mapped[i] = s.MapPayload(mapper)
+		} else {
+			mapped[i] = s
+		}
+	}
+	return NewGroup().withSignals(mapped)
+}
+
 // MapPayloads returns a new group with payloads transformed by the mapper function.
 func (g *Group) MapPayloads(mapper PayloadMapper) *Group {
 	if g.HasChainableErr() {

--- a/signal/group_test.go
+++ b/signal/group_test.go
@@ -893,6 +893,63 @@ func TestGroup_ForEach(t *testing.T) {
 	})
 }
 
+func TestGroup_ForEachIf(t *testing.T) {
+	t.Run("applies action only to matching signals", func(t *testing.T) {
+		group := NewGroup(1, 2, 3, 4)
+		count := 0
+		group.ForEachIf(
+			func(s *Signal) bool {
+				payload, _ := s.Payload()
+				return payload.(int)%2 == 0
+			},
+			func(s *Signal) error {
+				count++
+				return nil
+			},
+		)
+		assert.Equal(t, 2, count) // 2 and 4
+	})
+
+	t.Run("applies action to all when predicate always true", func(t *testing.T) {
+		group := NewGroup(1, 2, 3)
+		count := 0
+		group.ForEachIf(
+			func(s *Signal) bool { return true },
+			func(s *Signal) error { count++; return nil },
+		)
+		assert.Equal(t, 3, count)
+	})
+
+	t.Run("applies action to none when predicate always false", func(t *testing.T) {
+		group := NewGroup(1, 2, 3)
+		count := 0
+		group.ForEachIf(
+			func(s *Signal) bool { return false },
+			func(s *Signal) error { count++; return nil },
+		)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("stops on error and sets chainable error", func(t *testing.T) {
+		group := NewGroup(2, 4, 6)
+		result := group.ForEachIf(
+			func(s *Signal) bool { return true },
+			func(s *Signal) error { return assert.AnError },
+		)
+		assert.True(t, result.HasChainableErr())
+	})
+
+	t.Run("skips when group has error", func(t *testing.T) {
+		group := NewGroup(1, 2, 3).WithChainableErr(assert.AnError)
+		visited := false
+		group.ForEachIf(
+			func(s *Signal) bool { return true },
+			func(s *Signal) error { visited = true; return nil },
+		)
+		assert.False(t, visited)
+	})
+}
+
 func TestGroup_Len(t *testing.T) {
 	t.Run("returns count of signals", func(t *testing.T) {
 		group := NewGroup(1, 2, 3)

--- a/signal/group_test.go
+++ b/signal/group_test.go
@@ -616,6 +616,80 @@ func TestGroup_MapIf(t *testing.T) {
 	}
 }
 
+func TestGroup_MapPayloadsIf(t *testing.T) {
+	type args struct {
+		predicate  Predicate
+		mapperFunc PayloadMapper
+	}
+	tests := []struct {
+		name  string
+		group *Group
+		args  args
+		want  *Group
+	}{
+		{
+			name:  "empty group",
+			group: NewGroup(),
+			args: args{
+				predicate:  func(s *Signal) bool { return true },
+				mapperFunc: func(p any) any { return p.(int) * 2 },
+			},
+			want: NewGroup(),
+		},
+		{
+			name:  "predicate matches all - all payloads mapped",
+			group: NewGroup(1, 2, 3),
+			args: args{
+				predicate:  func(s *Signal) bool { return true },
+				mapperFunc: func(p any) any { return p.(int) * 10 },
+			},
+			want: NewGroup(10, 20, 30),
+		},
+		{
+			name:  "predicate matches none - no payloads changed",
+			group: NewGroup(1, 2, 3),
+			args: args{
+				predicate:  func(s *Signal) bool { return false },
+				mapperFunc: func(p any) any { return -1 },
+			},
+			want: NewGroup(1, 2, 3),
+		},
+		{
+			name:  "predicate matches some - only matching payloads mapped",
+			group: NewGroup(1, 2, 3, 4),
+			args: args{
+				predicate: func(s *Signal) bool {
+					payload, _ := s.Payload()
+					return payload.(int)%2 == 0
+				},
+				mapperFunc: func(p any) any { return p.(int) * 100 },
+			},
+			want: NewGroup(1, 200, 3, 400),
+		},
+		{
+			name:  "with error in chain",
+			group: NewGroup(1, 2, 3).WithChainableErr(errors.New("some error in chain")),
+			args: args{
+				predicate:  func(s *Signal) bool { return true },
+				mapperFunc: func(p any) any { return p },
+			},
+			want: NewGroup().WithChainableErr(errors.New("some error in chain")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.group.MapPayloadsIf(tt.args.predicate, tt.args.mapperFunc)
+			if tt.want.HasChainableErr() {
+				assert.Error(t, got.ChainableErr())
+				assert.EqualError(t, got.ChainableErr(), tt.want.ChainableErr().Error())
+			} else {
+				assert.NoError(t, got.ChainableErr())
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestGroup_MapPayloads(t *testing.T) {
 	type args struct {
 		mapperFunc PayloadMapper

--- a/signal/group_test.go
+++ b/signal/group_test.go
@@ -536,6 +536,86 @@ func TestGroup_Map(t *testing.T) {
 	}
 }
 
+func TestGroup_MapIf(t *testing.T) {
+	type args struct {
+		predicate  Predicate
+		mapperFunc Mapper
+	}
+	tests := []struct {
+		name  string
+		group *Group
+		args  args
+		want  *Group
+	}{
+		{
+			name:  "empty group",
+			group: NewGroup(),
+			args: args{
+				predicate: func(s *Signal) bool { return true },
+				mapperFunc: func(s *Signal) *Signal {
+					return s.MapPayload(func(p any) any { return p.(int) * 2 })
+				},
+			},
+			want: NewGroup(),
+		},
+		{
+			name:  "predicate matches all - all mapped",
+			group: NewGroup(1, 2, 3),
+			args: args{
+				predicate: func(s *Signal) bool { return true },
+				mapperFunc: func(s *Signal) *Signal {
+					return s.MapPayload(func(p any) any { return p.(int) * 10 })
+				},
+			},
+			want: NewGroup(10, 20, 30),
+		},
+		{
+			name:  "predicate matches none - nothing mapped",
+			group: NewGroup(1, 2, 3),
+			args: args{
+				predicate:  func(s *Signal) bool { return false },
+				mapperFunc: func(s *Signal) *Signal { return s.MapPayload(func(p any) any { return -1 }) },
+			},
+			want: NewGroup(1, 2, 3),
+		},
+		{
+			name:  "predicate matches some - only matching signals mapped",
+			group: NewGroup(1, 2, 3, 4),
+			args: args{
+				predicate: func(s *Signal) bool {
+					payload, _ := s.Payload()
+					return payload.(int)%2 == 0
+				},
+				mapperFunc: func(s *Signal) *Signal {
+					return s.MapPayload(func(p any) any { return p.(int) * 100 })
+				},
+			},
+			want: NewGroup(1, 200, 3, 400),
+		},
+		{
+			name:  "with error in chain",
+			group: NewGroup(1, 2, 3).WithChainableErr(errors.New("some error in chain")),
+			args: args{
+				predicate:  func(s *Signal) bool { return true },
+				mapperFunc: func(s *Signal) *Signal { return s },
+			},
+			want: NewGroup().WithChainableErr(errors.New("some error in chain")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.group.MapIf(tt.args.predicate, tt.args.mapperFunc)
+			if tt.want.HasChainableErr() {
+				assert.Error(t, got.ChainableErr())
+				assert.EqualError(t, got.ChainableErr(), tt.want.ChainableErr().Error())
+			} else {
+				assert.NoError(t, got.ChainableErr())
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestGroup_MapPayloads(t *testing.T) {
 	type args struct {
 		mapperFunc PayloadMapper

--- a/signal/group_test.go
+++ b/signal/group_test.go
@@ -301,6 +301,41 @@ func TestGroup_First(t *testing.T) {
 	})
 }
 
+func TestGroup_Find(t *testing.T) {
+	t.Run("returns first matching signal", func(t *testing.T) {
+		group := NewGroup(1, 2, 3, 4)
+		got := group.Find(func(s *Signal) bool {
+			payload, _ := s.Payload()
+			return payload.(int)%2 == 0
+		})
+		require.NotNil(t, got)
+		payload, err := got.Payload()
+		require.NoError(t, err)
+		assert.Equal(t, 2, payload) // first even, not all evens
+	})
+
+	t.Run("returns nil when no signal matches", func(t *testing.T) {
+		group := NewGroup(1, 3, 5)
+		got := group.Find(func(s *Signal) bool {
+			payload, _ := s.Payload()
+			return payload.(int)%2 == 0
+		})
+		assert.Nil(t, got)
+	})
+
+	t.Run("returns nil for empty group", func(t *testing.T) {
+		group := NewGroup()
+		got := group.Find(func(s *Signal) bool { return true })
+		assert.Nil(t, got)
+	})
+
+	t.Run("returns nil when group has error", func(t *testing.T) {
+		group := NewGroup(1, 2, 3).WithChainableErr(assert.AnError)
+		got := group.Find(func(s *Signal) bool { return true })
+		assert.Nil(t, got)
+	})
+}
+
 func TestGroup_Signals(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
This pull request introduces new higher-order methods to the `Group` types in the `cycle`, `port`, and `signal` packages, enhancing their functional programming capabilities. The main additions are `ForEachIf`, `Find`, and `MapIf` methods, which allow conditional iteration, searching, and mapping based on predicates. Comprehensive unit tests have been added for these new methods to ensure correctness and robustness. Additionally, some minor improvements were made to error propagation and consistency across these group types.

### New higher-order methods for Group types

- Added `ForEachIf` to `cycle.Group`, `port.Group`, and `signal.Group`, allowing actions to be applied only to elements matching a predicate. [[1]](diffhunk://#diff-391ceb83b586ffb2043b31c6da68f37b07ba0b9bda3a9fd314278b74f564591dR61-R76) [[2]](diffhunk://#diff-e6187ec861b7a2288d8fd313000f24f97947ff3cd2e9a6b7f734fe0ea9f9855cR86-R101) [[3]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eR283-R302)
- Introduced `Find` to all three Group types, returning the first element matching a predicate or `nil` if none match. [[1]](diffhunk://#diff-391ceb83b586ffb2043b31c6da68f37b07ba0b9bda3a9fd314278b74f564591dR126-R138) [[2]](diffhunk://#diff-e6187ec861b7a2288d8fd313000f24f97947ff3cd2e9a6b7f734fe0ea9f9855cL127-R158) [[3]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eR43-R55)
- Implemented `MapIf` for all Group types, conditionally transforming elements that match a predicate, while leaving others unchanged and dropping `nil` results. [[1]](diffhunk://#diff-391ceb83b586ffb2043b31c6da68f37b07ba0b9bda3a9fd314278b74f564591dR211-R236) [[2]](diffhunk://#diff-e6187ec861b7a2288d8fd313000f24f97947ff3cd2e9a6b7f734fe0ea9f9855cR223-R248) [[3]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eR329-R364)
- Added `MapPayloadsIf` to `signal.Group`, enabling conditional payload mapping.

### Testing improvements

- Added comprehensive unit tests for `ForEachIf`, `Find`, and `MapIf` methods in `cycle/group_test.go`, `port/group_test.go`, and `signal/group_test.go`, covering normal cases, error propagation, and edge cases. [[1]](diffhunk://#diff-a1b75bbdd467e42fb63ac57a83ebe9d0e4f0e3ca1a64119ae864e1a38aa5bb4dR155-R210) [[2]](diffhunk://#diff-a1b75bbdd467e42fb63ac57a83ebe9d0e4f0e3ca1a64119ae864e1a38aa5bb4dR246-R277) [[3]](diffhunk://#diff-a1b75bbdd467e42fb63ac57a83ebe9d0e4f0e3ca1a64119ae864e1a38aa5bb4dR400-R451) [[4]](diffhunk://#diff-14c1cb6b30899defdee5ceb0bb6f5ae7a174b9ac689dc77dfe3af076042cc3edR203-R253) [[5]](diffhunk://#diff-14c1cb6b30899defdee5ceb0bb6f5ae7a174b9ac689dc77dfe3af076042cc3edR350-R399) [[6]](diffhunk://#diff-14c1cb6b30899defdee5ceb0bb6f5ae7a174b9ac689dc77dfe3af076042cc3edR462-R492) [[7]](diffhunk://#diff-e83c55130e0b1946d88bf89bd28c2cf6fd143666c7cfc5ce9a14dac0af9be23fR304-R338)

### Error handling and consistency

- Improved error propagation in `signal.Group` methods (`Without`, `Filter`, `Map`, `MapPayloads`) to consistently return a new group with the chainable error, rather than mutating or returning the original group. [[1]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eL175-R188) [[2]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eR283-R302) [[3]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eL291-R318) [[4]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eR329-R364)

### Minor code cleanup

- Removed an unused import from `port/group.go`.
- Removed the unused `AddLabelsToAll` method from `port.Group`.