### PR TITLE
Signal immutability

### DIFF
--- a/integration_tests/component_hooks/basic_test.go
+++ b/integration_tests/component_hooks/basic_test.go
@@ -2,6 +2,7 @@ package componenthooks
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/hovsep/fmesh"
@@ -223,14 +224,14 @@ func TestComponentHooks_ContextAccess(t *testing.T) {
 }
 
 func TestComponentHooks_IntegrationWithFMesh(t *testing.T) {
-	var componentActivations []string
+	var log hookLog
 
 	c1 := component.New("c1").
 		AddInputs("in").
 		AddOutputs("out").
 		SetupHooks(func(h *component.Hooks) {
 			h.BeforeActivation(func(c *component.Component) error {
-				componentActivations = append(componentActivations, c.Name())
+				log.add(c.Name())
 				return nil
 			})
 		}).
@@ -243,7 +244,7 @@ func TestComponentHooks_IntegrationWithFMesh(t *testing.T) {
 		AddInputs("in").
 		SetupHooks(func(h *component.Hooks) {
 			h.BeforeActivation(func(c *component.Component) error {
-				componentActivations = append(componentActivations, c.Name())
+				log.add(c.Name())
 				return nil
 			})
 		}).
@@ -260,12 +261,13 @@ func TestComponentHooks_IntegrationWithFMesh(t *testing.T) {
 	require.NoError(t, err)
 
 	// Both components should have activated
+	componentActivations := log.snapshot()
 	assert.Contains(t, componentActivations, "c1")
 	assert.Contains(t, componentActivations, "c2")
 }
 
 func TestComponentHooks_ExecutionOrderAcrossComponents(t *testing.T) {
-	var executionLog []string
+	var log hookLog
 
 	// Create three components with hooks
 	c1 := component.New("c1").
@@ -273,15 +275,15 @@ func TestComponentHooks_ExecutionOrderAcrossComponents(t *testing.T) {
 		AddOutputs("out").
 		SetupHooks(func(h *component.Hooks) {
 			h.BeforeActivation(func(c *component.Component) error {
-				executionLog = append(executionLog, "c1:before")
+				log.add("c1:before")
 				return nil
 			})
 			h.OnSuccess(func(ctx *component.ActivationContext) error {
-				executionLog = append(executionLog, "c1:success")
+				log.add("c1:success")
 				return nil
 			})
 			h.AfterActivation(func(ctx *component.ActivationContext) error {
-				executionLog = append(executionLog, "c1:after")
+				log.add("c1:after")
 				return nil
 			})
 		}).
@@ -295,15 +297,15 @@ func TestComponentHooks_ExecutionOrderAcrossComponents(t *testing.T) {
 		AddOutputs("out").
 		SetupHooks(func(h *component.Hooks) {
 			h.BeforeActivation(func(c *component.Component) error {
-				executionLog = append(executionLog, "c2:before")
+				log.add("c2:before")
 				return nil
 			})
 			h.OnSuccess(func(ctx *component.ActivationContext) error {
-				executionLog = append(executionLog, "c2:success")
+				log.add("c2:success")
 				return nil
 			})
 			h.AfterActivation(func(ctx *component.ActivationContext) error {
-				executionLog = append(executionLog, "c2:after")
+				log.add("c2:after")
 				return nil
 			})
 		}).
@@ -316,15 +318,15 @@ func TestComponentHooks_ExecutionOrderAcrossComponents(t *testing.T) {
 		AddInputs("in").
 		SetupHooks(func(h *component.Hooks) {
 			h.BeforeActivation(func(c *component.Component) error {
-				executionLog = append(executionLog, "c3:before")
+				log.add("c3:before")
 				return nil
 			})
 			h.OnSuccess(func(ctx *component.ActivationContext) error {
-				executionLog = append(executionLog, "c3:success")
+				log.add("c3:success")
 				return nil
 			})
 			h.AfterActivation(func(ctx *component.ActivationContext) error {
-				executionLog = append(executionLog, "c3:after")
+				log.add("c3:after")
 				return nil
 			})
 		}).
@@ -342,6 +344,8 @@ func TestComponentHooks_ExecutionOrderAcrossComponents(t *testing.T) {
 
 	_, err := fm.Run()
 	require.NoError(t, err)
+
+	executionLog := log.snapshot()
 
 	// Verify all components activated with proper hook order
 	// c1 and c2 fire in cycle 1, c3 in cycle 2
@@ -440,6 +444,26 @@ func BenchmarkComponentHooks_Overhead(b *testing.B) {
 			c.InputByName("in").PutSignals(signal.New(1))
 		}
 	})
+}
+
+// hookLog collects hook events from parallel component activations safely.
+type hookLog struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *hookLog) add(s string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, s)
+}
+
+func (l *hookLog) snapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.lines))
+	copy(out, l.lines)
+	return out
 }
 
 // Helper function for finding index in slice.

--- a/integration_tests/piping/fan_out_concurrency_integration_test.go
+++ b/integration_tests/piping/fan_out_concurrency_integration_test.go
@@ -95,18 +95,18 @@ func TestFanOut_sharedSignal_parallelStress_completes(t *testing.T) {
 
 				switch mode {
 				case 0:
-					for i := 0; i < stressIters; i++ {
+					for i := range stressIters {
 						_ = shared.MapPayload(func(p any) any {
 							_ = i
 							return p
 						})
 					}
 				case 1:
-					for i := 0; i < stressIters; i++ {
+					for i := range stressIters {
 						shared.AddLabel(fmt.Sprintf("w1_%d", i), "v")
 					}
 				default:
-					for i := 0; i < stressIters; i++ {
+					for i := range stressIters {
 						shared.AddLabel(fmt.Sprintf("w2_%d", i), "v")
 					}
 				}

--- a/integration_tests/piping/fan_out_concurrency_integration_test.go
+++ b/integration_tests/piping/fan_out_concurrency_integration_test.go
@@ -1,0 +1,144 @@
+package piping
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/hovsep/fmesh"
+	"github.com/hovsep/fmesh/component"
+	"github.com/hovsep/fmesh/port"
+	"github.com/hovsep/fmesh/signal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFanOut_threeConsumers_seeSameSignalPointer asserts fan-out wiring: one
+// signal instance is delivered to every downstream port, and fmesh activates
+// components in parallel (see fmesh.runCycle).
+func TestFanOut_threeConsumers_seeSameSignalPointer(t *testing.T) {
+	var ptrs sync.Map
+
+	producer := component.New("producer").
+		AddInputs("start").
+		AddOutputs("o1").
+		WithActivationFunc(func(this *component.Component) error {
+			this.OutputByName("o1").PutSignals(signal.New(42).AddLabel("route", "fan"))
+			return nil
+		})
+
+	makeConsumer := func(name, slot string) *component.Component {
+		return component.New(name).
+			AddInputs("i1").
+			AddOutputs("o1").
+			WithActivationFunc(func(this *component.Component) error {
+				first := this.InputByName("i1").Signals().First()
+				if first != nil {
+					ptrs.Store(slot, uintptr(unsafe.Pointer(first)))
+				}
+				return port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))
+			})
+	}
+
+	c1 := makeConsumer("consumer1", "1")
+	c2 := makeConsumer("consumer2", "2")
+	c3 := makeConsumer("consumer3", "3")
+
+	fm := fmesh.New("fan-out-same-pointer").AddComponents(producer, c1, c2, c3)
+	fm.Components().ByName("producer").OutputByName("o1").PipeTo(
+		fm.Components().ByName("consumer1").InputByName("i1"),
+		fm.Components().ByName("consumer2").InputByName("i1"),
+		fm.Components().ByName("consumer3").InputByName("i1"),
+	)
+
+	fm.Components().ByName("producer").InputByName("start").PutSignals(signal.New(struct{}{}))
+
+	_, err := fm.Run()
+	require.NoError(t, err)
+
+	p1, ok1 := ptrs.Load("1")
+	p2, ok2 := ptrs.Load("2")
+	p3, ok3 := ptrs.Load("3")
+	require.True(t, ok1 && ok2 && ok3, "each consumer should have recorded a non-nil *signal.Signal")
+
+	assert.Equal(t, p1, p2, "fan-out must deliver the same *Signal pointer to each consumer (#203)")
+	assert.Equal(t, p2, p3, "fan-out must deliver the same *Signal pointer to each consumer (#203)")
+}
+
+// TestFanOut_sharedSignal_parallelStress_completes exercises the same fan-out
+// plus concurrent label work on the shared *signal.Signal. With copy-on-write
+// signals this completes cleanly; run with -race to confirm no data races.
+func TestFanOut_sharedSignal_parallelStress_completes(t *testing.T) {
+	const stressIters = 400
+
+	var ptrs sync.Map
+
+	producer := component.New("producer").
+		AddInputs("start").
+		AddOutputs("o1").
+		WithActivationFunc(func(this *component.Component) error {
+			this.OutputByName("o1").PutSignals(signal.New(1).AddLabel("seed", "x"))
+			return nil
+		})
+
+	makeConsumer := func(name string, mode int) *component.Component {
+		return component.New(name).
+			AddInputs("i1").
+			AddOutputs("o1").
+			WithActivationFunc(func(this *component.Component) error {
+				shared := this.InputByName("i1").Signals().First()
+				if shared == nil {
+					return nil
+				}
+				ptrs.Store(name, uintptr(unsafe.Pointer(shared)))
+
+				switch mode {
+				case 0:
+					for i := 0; i < stressIters; i++ {
+						_ = shared.MapPayload(func(p any) any {
+							_ = i
+							return p
+						})
+					}
+				case 1:
+					for i := 0; i < stressIters; i++ {
+						shared.AddLabel(fmt.Sprintf("w1_%d", i), "v")
+					}
+				default:
+					for i := 0; i < stressIters; i++ {
+						shared.AddLabel(fmt.Sprintf("w2_%d", i), "v")
+					}
+				}
+				return port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))
+			})
+	}
+
+	fm := fmesh.NewWithConfig("fan-out-stress", &fmesh.Config{
+		ErrorHandlingStrategy: fmesh.IgnoreAll,
+	}).AddComponents(
+		producer,
+		makeConsumer("consumerA", 0),
+		makeConsumer("consumerB", 1),
+		makeConsumer("consumerC", 2),
+	)
+
+	fm.Components().ByName("producer").OutputByName("o1").PipeTo(
+		fm.Components().ByName("consumerA").InputByName("i1"),
+		fm.Components().ByName("consumerB").InputByName("i1"),
+		fm.Components().ByName("consumerC").InputByName("i1"),
+	)
+
+	fm.Components().ByName("producer").InputByName("start").PutSignals(signal.New(struct{}{}))
+
+	_, err := fm.Run()
+	require.NoError(t, err)
+
+	pA, okA := ptrs.Load("consumerA")
+	pB, okB := ptrs.Load("consumerB")
+	pC, okC := ptrs.Load("consumerC")
+	require.True(t, okA && okB && okC)
+
+	assert.Equal(t, pA, pB)
+	assert.Equal(t, pB, pC)
+}

--- a/labels/immutability_test.go
+++ b/labels/immutability_test.go
@@ -1,0 +1,37 @@
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Contract tests for github.com/hovsep/fmesh#203 (Collection.All must not alias internal map).
+
+func TestLabelsCollection_All_returnsDefensiveCopy(t *testing.T) {
+	c := NewCollection().Add("k", "v")
+	m, err := c.All()
+	require.NoError(t, err)
+
+	m["k"] = "mutated"
+
+	assert.True(t, c.ValueIs("k", "v"),
+		"mutating the map from All() must not change the collection (#203)")
+}
+
+func TestLabelsCollection_All_map_not_shared_with_AddMany(t *testing.T) {
+	c1 := NewCollection().AddMany(Map{"a": "1", "b": "2"})
+	m, err := c1.All()
+	require.NoError(t, err)
+
+	c2 := NewCollection().AddMany(m)
+
+	m["a"] = "hacked"
+	m["b"] = "hacked"
+
+	assert.True(t, c1.ValueIs("a", "1"), "c1 must not observe mutation of map returned from All()")
+	assert.True(t, c1.ValueIs("b", "2"))
+	assert.True(t, c2.ValueIs("a", "1"), "c2 built from All() map must not share live map with c1")
+	assert.True(t, c2.ValueIs("b", "2"))
+}

--- a/labels/labels.go
+++ b/labels/labels.go
@@ -2,6 +2,7 @@ package labels
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 )
 
@@ -19,12 +20,13 @@ func NewCollection() *Collection {
 	}
 }
 
-// All returns all labels as a map.
+// All returns all labels as a map (a defensive copy; mutating the returned map
+// does not change the collection).
 func (c *Collection) All() (Map, error) {
 	if c.HasChainableErr() {
 		return nil, c.ChainableErr()
 	}
-	return c.labels, nil
+	return maps.Clone(c.labels), nil
 }
 
 // AllMatch returns true if all labels in the collection satisfy the predicate.

--- a/signal/doc.go
+++ b/signal/doc.go
@@ -1,0 +1,9 @@
+// Package signal provides [Signal] and [Group], the mesh's core data carriers.
+//
+// [Signal] and [Group] use copy-on-write: methods that appear to mutate return
+// new values and never modify the receiver. [Group.All] returns a copy of the
+// slice; [Signal.Labels] returns a defensive copy of the label collection.
+// [Group.ForEach] does not update the receiver on success; label changes on
+// grouped signals should be done with [Group.Map] / [Group.MapPayloads] so
+// replaced signals are stored in the new group (github.com/hovsep/fmesh#203).
+package signal

--- a/signal/group.go
+++ b/signal/group.go
@@ -8,30 +8,30 @@ type Group struct {
 	signals      Signals
 }
 
+func newGroupFromSignals(signals Signals) *Group {
+	return &Group{
+		chainableErr: nil,
+		signals:      slices.Clone(signals),
+	}
+}
+
 // NewGroup creates an empty group.
 func NewGroup(payloads ...any) *Group {
-	newGroup := &Group{
-		chainableErr: nil,
-	}
-
 	signals := make(Signals, len(payloads))
 	for i, payload := range payloads {
 		signals[i] = New(payload)
 	}
-	return newGroup.withSignals(signals)
+	return newGroupFromSignals(signals)
 }
 
 // First returns the first signal in the group.
-// Returns nil if the group is empty or has an error.
 func (g *Group) First() *Signal {
 	if g.HasChainableErr() {
 		return nil
 	}
-
 	if g.IsEmpty() {
 		return nil
 	}
-
 	return g.signals[0]
 }
 
@@ -55,69 +55,38 @@ func (g *Group) Find(predicate Predicate) *Signal {
 
 // AnyMatch returns true if at least one signal matches the predicate.
 func (g *Group) AnyMatch(p Predicate) bool {
-	if g.HasChainableErr() {
+	if g.HasChainableErr() || g.IsEmpty() {
 		return false
 	}
-
-	if g.IsEmpty() {
-		return false
-	}
-
 	return slices.ContainsFunc(g.signals, p)
 }
 
 // AllMatch returns true if all signals match the predicate.
 func (g *Group) AllMatch(p Predicate) bool {
-	if g.HasChainableErr() {
+	if g.HasChainableErr() || g.IsEmpty() {
 		return false
 	}
-
-	if g.IsEmpty() {
-		return false
-	}
-
 	for _, sig := range g.signals {
 		if !p(sig) {
 			return false
 		}
 	}
-
 	return true
 }
 
 // FirstPayload returns the payload of the first signal with error handling.
-// Use this when you need explicit error handling.
-//
-// Example (in activation function):
-//
-//	payload, err := this.InputByName("data").Signals().FirstPayload()
-//	if err != nil {
-//	    return err // Handle the error
-//	}
-//	data := payload.(string)
 func (g *Group) FirstPayload() (any, error) {
 	if g.HasChainableErr() {
 		return nil, g.ChainableErr()
 	}
-
 	first := g.First()
 	if first == nil {
 		return nil, ErrNoSignalsInGroup
 	}
-
 	return first.Payload()
 }
 
 // FirstPayloadOrDefault returns the payload of the first signal or a default value.
-// This is the most commonly used method for reading input data.
-// Returns the default if no signals exist or an error occurs.
-//
-// Example (in activation function):
-//
-//	// Read with type-appropriate defaults
-//	name := this.InputByName("name").Signals().FirstPayloadOrDefault("").(string)
-//	count := this.InputByName("count").Signals().FirstPayloadOrDefault(0).(int)
-//	enabled := this.InputByName("enabled").Signals().FirstPayloadOrDefault(false).(bool)
 func (g *Group) FirstPayloadOrDefault(defaultPayload any) any {
 	payload, err := g.FirstPayload()
 	if err != nil {
@@ -127,14 +96,6 @@ func (g *Group) FirstPayloadOrDefault(defaultPayload any) any {
 }
 
 // FirstPayloadOrNil returns the payload of the first signal or nil.
-// Use this when nil is a valid/expected value for missing signals.
-//
-// Example (in activation function):
-//
-//	optionalData := this.InputByName("optional").Signals().FirstPayloadOrNil()
-//	if optionalData != nil {
-//	    // Process optional data
-//	}
 func (g *Group) FirstPayloadOrNil() any {
 	return g.FirstPayloadOrDefault(nil)
 }
@@ -144,42 +105,34 @@ func (g *Group) AllPayloads() ([]any, error) {
 	if g.HasChainableErr() {
 		return nil, g.ChainableErr()
 	}
-
 	all := make([]any, g.Len())
-	var err error
 	for i, sig := range g.signals {
-		all[i], err = sig.Payload()
+		p, err := sig.Payload()
 		if err != nil {
 			return nil, err
 		}
+		all[i] = p
 	}
 	return all, nil
 }
 
-// Add returns the group with added signals.
+// Add returns a new group with added signals. The receiver is never modified.
 func (g *Group) Add(signals ...*Signal) *Group {
 	if g.HasChainableErr() {
-		// Do nothing but propagate the error
 		return g
 	}
-
 	newSignals := make(Signals, g.Len()+len(signals))
 	copy(newSignals, g.signals)
 	for i, sig := range signals {
 		if sig == nil {
-			g.WithChainableErr(ErrInvalidSignal)
-			return NewGroup().WithChainableErr(g.ChainableErr())
+			return NewGroup().WithChainableErr(ErrInvalidSignal)
 		}
-
 		if sig.HasChainableErr() {
-			g.WithChainableErr(sig.ChainableErr())
-			return NewGroup().WithChainableErr(g.ChainableErr())
+			return NewGroup().WithChainableErr(sig.ChainableErr())
 		}
-
 		newSignals[g.Len()+i] = sig
 	}
-
-	return g.withSignals(newSignals)
+	return newGroupFromSignals(newSignals)
 }
 
 // Without removes signals matching the predicate and returns a new group.
@@ -187,57 +140,38 @@ func (g *Group) Without(predicate Predicate) *Group {
 	if g.HasChainableErr() {
 		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
-	// Keep signals that DON'T match the predicate
 	return g.Filter(func(s *Signal) bool {
 		return !predicate(s)
 	})
 }
 
-// AddFromPayloads returns a group with added signals created from provided payloads.
+// AddFromPayloads returns a new group with added signals created from provided payloads.
 func (g *Group) AddFromPayloads(payloads ...any) *Group {
 	if g.HasChainableErr() {
-		// Do nothing but propagate the error
 		return g
 	}
-
 	newSignals := make(Signals, g.Len()+len(payloads))
 	copy(newSignals, g.signals)
 	for i, p := range payloads {
 		newSignals[g.Len()+i] = New(p)
 	}
-	return g.withSignals(newSignals)
+	return newGroupFromSignals(newSignals)
 }
 
-// withSignals sets signals.
-func (g *Group) withSignals(signals Signals) *Group {
-	g.signals = signals
-	return g
-}
-
-// All returns all signals in the group as a slice.
-// Use this when you need to iterate over multiple signals or batch process.
-//
-// Example (in activation function):
-//
-//	signals, err := this.InputByName("batch").Signals().All()
-//	if err != nil {
-//	    return err
-//	}
-//	for _, sig := range signals {
-//	    payload, _ := sig.Payload()
-//	    // Process each signal
-//	}
+// All returns a copy of all signals in the group.
 func (g *Group) All() (Signals, error) {
 	if g.HasChainableErr() {
 		return nil, g.ChainableErr()
 	}
-	return g.signals, nil
+	return slices.Clone(g.signals), nil
 }
 
-// WithChainableErr sets a chainable error and returns the group.
+// WithChainableErr sets a chainable error and returns a new group.
 func (g *Group) WithChainableErr(err error) *Group {
-	g.chainableErr = err
-	return g
+	return &Group{
+		chainableErr: err,
+		signals:      slices.Clone(g.signals),
+	}
 }
 
 // HasChainableErr returns true when a chainable error is set.
@@ -251,13 +185,6 @@ func (g *Group) ChainableErr() error {
 }
 
 // Len returns the number of signals in the group.
-// Returns 0 if the group has a chainable error.
-// Use this to check how many signals are available or to iterate.
-//
-// Example (in activation function):
-//
-//	signalCount := this.InputByName("batch").Signals().Len()
-//	this.Logger().Printf("Processing %d items", signalCount)
 func (g *Group) Len() int {
 	if g.HasChainableErr() {
 		return 0
@@ -265,16 +192,15 @@ func (g *Group) Len() int {
 	return len(g.signals)
 }
 
-// ForEach applies the action to each signal and returns the group for chaining.
-// This is primarily intended for label manipulation as signals are immutable data.
+// ForEach applies the action to each signal and returns a result group.
+// On error the receiver is unchanged; the returned group carries the error.
 func (g *Group) ForEach(action func(*Signal) error) *Group {
 	if g.HasChainableErr() {
 		return g
 	}
 	for _, s := range g.signals {
 		if err := action(s); err != nil {
-			g.chainableErr = err
-			return g
+			return newGroupFromSignals(g.signals).WithChainableErr(err)
 		}
 	}
 	return g
@@ -288,8 +214,7 @@ func (g *Group) ForEachIf(predicate Predicate, action func(*Signal) error) *Grou
 	for _, s := range g.signals {
 		if predicate(s) {
 			if err := action(s); err != nil {
-				g.chainableErr = err
-				return g
+				return newGroupFromSignals(g.signals).WithChainableErr(err)
 			}
 		}
 	}
@@ -301,15 +226,13 @@ func (g *Group) Filter(p Predicate) *Group {
 	if g.HasChainableErr() {
 		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
-
-	filteredSignals := make(Signals, 0)
+	filtered := make(Signals, 0)
 	for _, s := range g.signals {
 		if p(s) {
-			filteredSignals = append(filteredSignals, s)
+			filtered = append(filtered, s)
 		}
 	}
-
-	return NewGroup().withSignals(filteredSignals)
+	return newGroupFromSignals(filtered)
 }
 
 // Map returns a new group with signals transformed by the mapper function.
@@ -317,13 +240,11 @@ func (g *Group) Map(m Mapper) *Group {
 	if g.HasChainableErr() {
 		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
-
-	mappedSignals := make(Signals, 0)
+	mapped := make(Signals, 0, len(g.signals))
 	for _, s := range g.signals {
-		mappedSignals = append(mappedSignals, s.Map(m))
+		mapped = append(mapped, s.Map(m))
 	}
-
-	return NewGroup().withSignals(mappedSignals)
+	return newGroupFromSignals(mapped)
 }
 
 // MapIf is like Map but only applies the mapper function to signals that match the predicate.
@@ -336,10 +257,10 @@ func (g *Group) MapIf(predicate Predicate, mapper Mapper) *Group {
 		if predicate(s) {
 			mapped[i] = s.Map(mapper)
 		} else {
-			mapped[i] = s
+			mapped[i] = cloneSignal(s)
 		}
 	}
-	return NewGroup().withSignals(mapped)
+	return newGroupFromSignals(mapped)
 }
 
 // MapPayloadsIf is like MapPayloads but only applies the mapper to signals that match the predicate.
@@ -352,10 +273,10 @@ func (g *Group) MapPayloadsIf(predicate Predicate, mapper PayloadMapper) *Group 
 		if predicate(s) {
 			mapped[i] = s.MapPayload(mapper)
 		} else {
-			mapped[i] = s
+			mapped[i] = cloneSignal(s)
 		}
 	}
-	return NewGroup().withSignals(mapped)
+	return newGroupFromSignals(mapped)
 }
 
 // MapPayloads returns a new group with payloads transformed by the mapper function.
@@ -363,13 +284,11 @@ func (g *Group) MapPayloads(mapper PayloadMapper) *Group {
 	if g.HasChainableErr() {
 		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
-
-	mappedSignals := make(Signals, 0)
+	mapped := make(Signals, 0, len(g.signals))
 	for _, s := range g.signals {
-		mappedSignals = append(mappedSignals, s.MapPayload(mapper))
+		mapped = append(mapped, s.MapPayload(mapper))
 	}
-
-	return NewGroup().withSignals(mappedSignals)
+	return newGroupFromSignals(mapped)
 }
 
 // CountMatch returns the number of signals that match the predicate.
@@ -377,11 +296,11 @@ func (g *Group) CountMatch(predicate Predicate) int {
 	if g.HasChainableErr() {
 		return 0
 	}
-	count := 0
+	n := 0
 	for _, sig := range g.signals {
 		if predicate(sig) {
-			count++
+			n++
 		}
 	}
-	return count
+	return n
 }

--- a/signal/group_test.go
+++ b/signal/group_test.go
@@ -132,7 +132,7 @@ func TestGroup_AllPayloads(t *testing.T) {
 		},
 		{
 			name:            "with error in signal",
-			group:           NewGroup().withSignals(Signals{New(33).WithChainableErr(errors.New("some error in signal"))}),
+			group:           newGroupFromSignals(Signals{New(33).WithChainableErr(errors.New("some error in signal"))}),
 			want:            nil,
 			wantErrorString: "some error in signal",
 		},
@@ -363,8 +363,8 @@ func TestGroup_Signals(t *testing.T) {
 		},
 		{
 			name: "with labeled signals",
-			group: NewGroup(1, nil, 3).ForEach(func(s *Signal) error {
-				return s.SetLabels(labels.Map{"flavor": "banana"}).ChainableErr()
+			group: NewGroup(1, nil, 3).Map(func(s *Signal) *Signal {
+				return s.SetLabels(labels.Map{"flavor": "banana"})
 			}),
 			want: Signals{
 				New(1).SetLabels(labels.Map{

--- a/signal/immutability_test.go
+++ b/signal/immutability_test.go
@@ -1,0 +1,191 @@
+package signal
+
+import (
+	"errors"
+	"testing"
+	"unsafe"
+
+	"github.com/hovsep/fmesh/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Contract tests for github.com/hovsep/fmesh#203 (immutability / non-poisoning).
+
+func TestSignal_immutable_builder_operations(t *testing.T) {
+	t.Run("AddLabel_leaves_receiver_unchanged", func(t *testing.T) {
+		orig := New(42).AddLabel("a", "1")
+		require.Equal(t, 1, orig.Labels().Len())
+		require.True(t, orig.Labels().ValueIs("a", "1"))
+
+		next := orig.AddLabel("b", "2")
+		require.NotNil(t, next)
+
+		assert.Equal(t, 1, orig.Labels().Len(), "receiver must keep prior labels only")
+		assert.True(t, orig.Labels().ValueIs("a", "1"))
+		assert.False(t, orig.Labels().Has("b"))
+
+		assert.Equal(t, 2, next.Labels().Len())
+		assert.True(t, next.Labels().Has("b"))
+	})
+
+	t.Run("AddLabels_leaves_receiver_unchanged", func(t *testing.T) {
+		orig := New(1).AddLabel("k", "v")
+		next := orig.AddLabels(labels.Map{"x": "y"})
+
+		assert.Equal(t, 1, orig.Labels().Len())
+		assert.True(t, orig.Labels().ValueIs("k", "v"))
+		assert.False(t, orig.Labels().Has("x"))
+
+		assert.Equal(t, 2, next.Labels().Len())
+		assert.True(t, next.Labels().Has("x"))
+	})
+
+	t.Run("SetLabels_leaves_receiver_unchanged", func(t *testing.T) {
+		orig := New(1).AddLabel("keep", "old")
+		next := orig.SetLabels(labels.Map{"new": "set"})
+
+		assert.True(t, orig.Labels().ValueIs("keep", "old"))
+		assert.False(t, orig.Labels().Has("new"))
+
+		assert.Equal(t, 1, next.Labels().Len())
+		assert.True(t, next.Labels().ValueIs("new", "set"))
+	})
+
+	t.Run("ClearLabels_leaves_receiver_unchanged", func(t *testing.T) {
+		orig := New(1).AddLabel("a", "1")
+		next := orig.ClearLabels()
+
+		assert.Equal(t, 1, orig.Labels().Len())
+		assert.True(t, orig.Labels().Has("a"))
+
+		assert.Equal(t, 0, next.Labels().Len())
+	})
+
+	t.Run("WithoutLabels_leaves_receiver_unchanged", func(t *testing.T) {
+		orig := New(1).AddLabels(labels.Map{"a": "1", "b": "2"})
+		next := orig.WithoutLabels("b")
+
+		assert.Equal(t, 2, orig.Labels().Len())
+		assert.True(t, orig.Labels().Has("b"))
+
+		assert.Equal(t, 1, next.Labels().Len())
+		assert.False(t, next.Labels().Has("b"))
+	})
+
+	t.Run("WithChainableErr_leaves_receiver_unchanged", func(t *testing.T) {
+		orig := New(7).AddLabel("k", "v")
+		sentinel := errors.New("sentinel")
+		next := orig.WithChainableErr(sentinel)
+
+		assert.False(t, orig.HasChainableErr())
+		_, err := orig.Payload()
+		require.NoError(t, err)
+
+		assert.True(t, next.HasChainableErr())
+		assert.Equal(t, sentinel, next.ChainableErr())
+	})
+}
+
+func TestSignal_MapPayload_leaves_receiver_unchanged(t *testing.T) {
+	orig := New(10).AddLabel("trace", "id")
+	next := orig.MapPayload(func(p any) any { return p.(int) * 2 })
+
+	p0, err := orig.Payload()
+	require.NoError(t, err)
+	assert.Equal(t, 10, p0)
+	assert.Equal(t, 1, orig.Labels().Len())
+	assert.True(t, orig.Labels().ValueIs("trace", "id"))
+
+	p1, err := next.Payload()
+	require.NoError(t, err)
+	assert.Equal(t, 20, p1)
+	assert.True(t, next.Labels().ValueIs("trace", "id"))
+}
+
+func TestGroup_Add_does_not_poison_receiver_on_invalid_signal(t *testing.T) {
+	t.Run("nil_signal", func(t *testing.T) {
+		g := NewGroup(1)
+		_ = g.Add(nil)
+
+		assert.False(t, g.HasChainableErr(), "receiver must not retain Add error")
+		assert.Equal(t, 1, g.Len())
+
+		g2 := g.Add(New(99))
+		assert.False(t, g2.HasChainableErr())
+		assert.Equal(t, 2, g2.Len())
+	})
+
+	t.Run("signal_with_chainable_error", func(t *testing.T) {
+		g := NewGroup(1)
+		bad := New(2).WithChainableErr(errors.New("bad signal"))
+		_ = g.Add(bad)
+
+		assert.False(t, g.HasChainableErr())
+		assert.Equal(t, 1, g.Len())
+
+		g2 := g.Add(New(3))
+		assert.False(t, g2.HasChainableErr())
+		assert.Equal(t, 2, g2.Len())
+	})
+}
+
+func TestGroup_ForEach_does_not_poison_receiver_on_error(t *testing.T) {
+	g := NewGroup(1, 2, 3)
+	_ = g.ForEach(func(*Signal) error { return errors.New("stop") })
+
+	assert.False(t, g.HasChainableErr(), "ForEach must not persist error on original group")
+	assert.Equal(t, 3, g.Len())
+}
+
+func TestGroup_ForEachIf_does_not_poison_receiver_on_error(t *testing.T) {
+	g := NewGroup(1, 2, 3)
+	_ = g.ForEachIf(
+		func(*Signal) bool { return true },
+		func(*Signal) error { return errors.New("stop") },
+	)
+
+	assert.False(t, g.HasChainableErr())
+	assert.Equal(t, 3, g.Len())
+}
+
+func TestGroup_MapIf_non_matching_signals_are_not_shared_pointers(t *testing.T) {
+	g := NewGroup(1, 2)
+	mapper := func(*Signal) *Signal {
+		require.Fail(t, "mapper must not run when predicate matches nothing")
+		return nil
+	}
+	out := g.MapIf(func(*Signal) bool { return false }, mapper)
+
+	outSigs, err := out.All()
+	require.NoError(t, err)
+	require.Len(t, outSigs, 2)
+	require.NotEqual(t, uintptr(unsafe.Pointer(g.First())), uintptr(unsafe.Pointer(outSigs[0])),
+		"MapIf pass-through must use cloned signals, not shared pointers (#203)")
+
+	_ = outSigs[0].AddLabel("x", "y")
+
+	assert.False(t, g.First().Labels().Has("x"),
+		"mutating output group's signal must not change original group's signal (#203)")
+}
+
+func TestGroup_MapPayloadsIf_non_matching_signals_are_not_shared_pointers(t *testing.T) {
+	g := NewGroup(1, 2)
+	out := g.MapPayloadsIf(
+		func(*Signal) bool { return false },
+		func(any) any {
+			require.Fail(t, "mapper must not run when predicate matches nothing")
+			return nil
+		},
+	)
+
+	outSigs, err := out.All()
+	require.NoError(t, err)
+	require.Len(t, outSigs, 2)
+	require.NotEqual(t, uintptr(unsafe.Pointer(g.First())), uintptr(unsafe.Pointer(outSigs[0])))
+
+	_ = outSigs[0].AddLabel("x", "y")
+
+	assert.False(t, g.First().Labels().Has("x"),
+		"mutating output group's signal must not change original group's signal (#203)")
+}

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -1,28 +1,44 @@
 package signal
 
 import (
+	"maps"
+	"slices"
+
 	"github.com/hovsep/fmesh/labels"
 )
 
 // Signal is a wrapper around the data flowing between components.
+// Mutating-style methods return a new *Signal; receivers are never modified.
 type Signal struct {
 	chainableErr error
 	labels       *labels.Collection
 	payload      []any // Slice is used in order to support nil payload
 }
 
+// cloneLabels returns an independent labels.Collection with the same entries.
+func cloneLabels(c *labels.Collection) *labels.Collection {
+	if c == nil {
+		return labels.NewCollection()
+	}
+	if c.HasChainableErr() {
+		return labels.NewCollection().WithChainableErr(c.ChainableErr())
+	}
+	return c.Filter(func(string, string) bool { return true })
+}
+
+// cloneSignal returns a deep copy suitable for aliasing-free group operations.
+func cloneSignal(s *Signal) *Signal {
+	if s == nil {
+		return nil
+	}
+	return &Signal{
+		chainableErr: s.chainableErr,
+		labels:       cloneLabels(s.labels),
+		payload:      slices.Clone(s.payload),
+	}
+}
+
 // New creates a new signal with the given payload.
-// Signals carry data between components through ports.
-// The payload can be any type (string, int, struct, slice, nil, etc.).
-//
-// Example (in activation function):
-//
-//	// Send a simple value
-//	this.OutputByName("count").PutSignals(signal.New(42))
-//
-//	// Send a complex value
-//	payload := map[string]interface{}{"status": "ok", "data": items}
-//	this.OutputByName("result").PutSignals(signal.New(payload))
 func New(payload any) *Signal {
 	return &Signal{
 		chainableErr: nil,
@@ -31,57 +47,70 @@ func New(payload any) *Signal {
 	}
 }
 
-// Labels returns the signal's labels collection.
+// Labels returns a defensive copy of the signal's labels collection.
 func (s *Signal) Labels() *labels.Collection {
 	if s.HasChainableErr() {
 		return labels.NewCollection().WithChainableErr(s.ChainableErr())
 	}
-	return s.labels
+	return cloneLabels(s.labels)
 }
 
-// SetLabels replaces all labels and returns the signal for chaining.
+// SetLabels replaces all labels and returns a new signal.
 func (s *Signal) SetLabels(labelMap labels.Map) *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	s.labels.Clear().AddMany(labelMap)
-	return s
+	next := s.cloneForMutation()
+	next.labels = labels.NewCollection().AddMany(maps.Clone(labelMap))
+	return next
 }
 
-// AddLabels adds or updates labels and returns the signal for chaining.
+// AddLabels adds or updates labels and returns a new signal.
 func (s *Signal) AddLabels(labelMap labels.Map) *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	s.labels.AddMany(labelMap)
-	return s
+	next := s.cloneForMutation()
+	next.labels = next.labels.AddMany(maps.Clone(labelMap))
+	return next
 }
 
-// AddLabel adds or updates a single label and returns the signal for chaining.
+// AddLabel adds or updates a single label and returns a new signal.
 func (s *Signal) AddLabel(name, value string) *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	s.labels.Add(name, value)
-	return s
+	next := s.cloneForMutation()
+	next.labels = next.labels.Add(name, value)
+	return next
 }
 
-// ClearLabels removes all labels and returns the signal for chaining.
+// ClearLabels removes all labels and returns a new signal.
 func (s *Signal) ClearLabels() *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	s.labels.Clear()
-	return s
+	next := s.cloneForMutation()
+	next.labels = labels.NewCollection()
+	return next
 }
 
-// WithoutLabels removes specific labels and returns the signal for chaining.
+// WithoutLabels removes specific labels and returns a new signal.
 func (s *Signal) WithoutLabels(names ...string) *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	s.labels.Without(names...)
-	return s
+	next := s.cloneForMutation()
+	next.labels = next.labels.Without(names...)
+	return next
+}
+
+func (s *Signal) cloneForMutation() *Signal {
+	return &Signal{
+		chainableErr: s.chainableErr,
+		labels:       cloneLabels(s.labels),
+		payload:      slices.Clone(s.payload),
+	}
 }
 
 // Payload returns the signal's payload.
@@ -106,10 +135,13 @@ func (s *Signal) PayloadOrDefault(defaultPayload any) any {
 	return payload
 }
 
-// WithChainableErr sets a chainable error and returns the signal.
+// WithChainableErr sets a chainable error and returns a new signal.
 func (s *Signal) WithChainableErr(err error) *Signal {
-	s.chainableErr = err
-	return s
+	return &Signal{
+		chainableErr: err,
+		labels:       cloneLabels(s.labels),
+		payload:      slices.Clone(s.payload),
+	}
 }
 
 // HasChainableErr returns true when a chainable error is set.
@@ -142,13 +174,7 @@ func (s *Signal) MapPayload(mapper PayloadMapper) *Signal {
 		return New(nil).WithChainableErr(err)
 	}
 
-	// Create new signal with mapped payload
-	newSignal := New(mapper(payload))
-
-	// Copy labels using ForEach
-	s.labels.ForEach(func(label, value string) error {
-		return newSignal.AddLabel(label, value).ChainableErr()
-	})
-
-	return newSignal
+	out := New(mapper(payload))
+	out.labels = cloneLabels(s.labels)
+	return out
 }


### PR DESCRIPTION
This pull request introduces important improvements to the immutability and concurrency safety of core data structures, especially around signal groups and label collections. It ensures that methods which previously could lead to shared mutable state now always return defensive copies, preventing accidental mutation and data races. Additionally, new integration and contract tests are added to verify these guarantees, and concurrency-safe logging is introduced in the component hooks integration tests.

### Immutability and Defensive Copying

* `labels.Collection.All` now returns a defensive copy of the internal map, preventing external code from mutating the label collection's state.
* `signal.Group.All` and `signal.Group.WithChainableErr` now return copies of the internal slice, ensuring group contents cannot be mutated via returned slices. [[1]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eL147-R174) [[2]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eL147-R174)
* All group-modifying methods (`Add`, `AddFromPayloads`, `Without`, `ForEach`, `ForEachIf`, etc.) have been updated to return new group instances, never modifying the receiver in place. (Fbd052ceL105R105, [[1]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eL254-R203) [[2]](diffhunk://#diff-c7d946e359ea8fc9bc6d0c74f14100edae00c3c7ca13c660b3bedbd0e1994c6eL291-R217)

### Concurrency and Test Improvements

* Introduced a concurrency-safe `hookLog` for collecting hook events in parallel component activations within `integration_tests/component_hooks/basic_test.go`. [[1]](diffhunk://#diff-fc6dc50fc8c59fc28d3ffa301ddeaadd4a8bb3c12a56ad697cfdaceb8c680409R5) [[2]](diffhunk://#diff-fc6dc50fc8c59fc28d3ffa301ddeaadd4a8bb3c12a56ad697cfdaceb8c680409L226-R234) [[3]](diffhunk://#diff-fc6dc50fc8c59fc28d3ffa301ddeaadd4a8bb3c12a56ad697cfdaceb8c680409L246-R247) [[4]](diffhunk://#diff-fc6dc50fc8c59fc28d3ffa301ddeaadd4a8bb3c12a56ad697cfdaceb8c680409R264-R286) [[5]](diffhunk://#diff-fc6dc50fc8c59fc28d3ffa301ddeaadd4a8bb3c12a56ad697cfdaceb8c680409L298-R308) [[6]](diffhunk://#diff-fc6dc50fc8c59fc28d3ffa301ddeaadd4a8bb3c12a56ad697cfdaceb8c680409L319-R329) [[7]](diffhunk://#diff-fc6dc50fc8c59fc28d3ffa301ddeaadd4a8bb3c12a56ad697cfdaceb8c680409R348-R349) [[8]](diffhunk://#diff-fc6dc50fc8c59fc28d3ffa301ddeaadd4a8bb3c12a56ad697cfdaceb8c680409R449-R468)

### New and Enhanced Tests

* Added contract tests in `labels/immutability_test.go` to ensure that label collections never expose internal maps for mutation, even when using `AddMany` and `All`.
* Added new fan-out concurrency integration tests in `integration_tests/piping/fan_out_concurrency_integration_test.go` to verify that signals are delivered as the same pointer to all consumers and that concurrent label mutations do not cause data races.

### Documentation

* Improved documentation in `signal/doc.go` to clarify copy-on-write and defensive copying semantics for signals and groups.

These changes significantly strengthen the safety and predictability of the core data structures and provide robust tests to prevent regressions in the future.