### PR TITLE
Signal immutability

### DIFF
--- a/.agent/docs/design.md
+++ b/.agent/docs/design.md
@@ -1,0 +1,37 @@
+# Design
+
+## Architecture
+
+| Concept | Type | Package |
+|---|---|---|
+| Data packet | `*Signal` | `signal` |
+| Ordered signal collection | `*signal.Group` | `signal` |
+| Key-value metadata | `*labels.Collection` | `labels` |
+| Component | `*component.Component` | `component` |
+| Data endpoint | `*port.Port` | `port` |
+| Connection | pipe via `PipeTo` (output→input only) | `port` |
+| Execution tick | `*cycle.Cycle` | `cycle` |
+
+## Invariants
+
+**`*Signal` and `*signal.Group` are copy-on-write.** Mutating methods return a new value; receiver is never modified. `cloneSignal(s)` is the single clone primitive — nil-safe, use it in all CoW methods.
+
+**Payload is shallow-copied.** Mutable reference payloads (map, slice, pointer) must be treated as immutable by the caller. `nil` is a valid payload and must survive all CoW operations unchanged.
+
+**`labels.Collection` is mutable.** It mutates in place. Do not make it CoW — `port` and `component` depend on mutation.
+
+**Chainable error pattern.** Errors are stored in `chainableErr` instead of returned. If `HasChainableErr()` is true, methods are no-ops and return `self`. Applies to all chainable types.
+
+**Fan-out shares pointers.** Output→input fan-out forwards the same `*Signal` pointers to all destinations. Do not add deep-copy to `ForwardSignals` or `Flush`.
+
+**No generics.** `signal`/`labels` use `any`; FBP requires mixed-type signal flows in one group.
+
+**Minimise `reflect`.** Only when no alternative exists. Current approved use: `reflect.TypeOf(payload).Comparable()` in `ContainsPayload` — always nil-guard before calling `.Comparable()`.
+
+## Package notes
+
+- **`signal`** — `payload` is `[]any{value}` (single-element slice so `nil` is valid). Predicate combinators and label constructors live in `predicates.go`.
+- **`labels`** — `Keys()`/`Values()` return sorted slices for determinism. `Merge(other)` is the one non-mutating method. `Every(pred)` on empty = `true` (vacuous truth).
+- **`port`** — `Flush()` fans out then clears source. `PipeTo` is output→input only.
+- **`component`** — `State` is `map[string]any`, persistent across cycles.
+- **`cycle`** — has its own `AnyMatch`/`AllMatch`/`CountMatch` on its collection type, independent of `signal.Group`.

--- a/.agent/docs/naming.md
+++ b/.agent/docs/naming.md
@@ -1,0 +1,32 @@
+# Naming
+
+## CoW vs mutating
+
+| Semantics | Prefix |
+|---|---|
+| Copy-on-write (returns new value) | `With` / `Without` |
+| Mutating (modifies receiver) | `Add` / `Remove` |
+
+Never mix. When adding a new method: does it return a new value or mutate? Pick the prefix accordingly.
+
+## Label operations by type
+
+| | CoW (`signal.Signal`) | Mutating (`port.Port`, `component.Component`) |
+|---|---|---|
+| Add/update one | `WithLabel(k, v)` | `AddLabel(k, v)` |
+| Add/update many | `WithLabels(map)` | `AddLabels(map)` |
+| Replace all | `WithOnlyLabels(map)` | `SetLabels(map)` |
+| Remove specific | `WithoutLabels(names...)` | `RemoveLabels(names...)` |
+| Remove all | `WithNoLabels()` | `ClearLabels()` |
+
+`labels.Collection` (mutating): `Add`, `AddMany`, `Remove`, `Clear`. `Merge(other)` is the one exception — returns a new collection.
+
+## Collection/group operations
+
+`Any(p)`, `Every(p)`, `Count(p)`, `Map`, `MapIf`, `Filter`, `ForEach`, `ForEachIf`, `Reduce`, `ReducePayloads`, `Join`.
+
+> `cycle`, `port`, `component` collections still use `AnyMatch`/`AllMatch`/`CountMatch` — not yet renamed.
+
+## Predicates
+
+Prefer combinators over inline closures: `Not`, `And`, `Or`, `HasLabel`, `LabelEquals`, `LabelContains`, `HasAllLabels`, `HasAnyLabel`.

--- a/.agent/docs/testing.md
+++ b/.agent/docs/testing.md
@@ -1,0 +1,15 @@
+# Testing
+
+## Style
+
+- Tests live alongside source, same package (`package signal` not `package signal_test`)
+- Table-driven by default; `t.Run` subtests for grouped inline assertions
+- `require` for preconditions and error checks (stops on failure); `assert` for value checks (continues)
+- No assertion helpers — use plain `assert`/`require` directly
+- Only allowed helper: `mustXxx()` panic-on-error for fixture setup, never for assertions
+
+## What to cover
+
+- CoW invariant: verify receiver is unchanged after every mutating method
+- Chainable error: verify methods are no-ops when `HasChainableErr()` is true
+- Edge cases: nil payload, empty group/collection, error-carrying input

--- a/.agent/docs/workflow.md
+++ b/.agent/docs/workflow.md
@@ -1,0 +1,18 @@
+# Workflow
+
+## Renames
+
+- Don't rely solely on sed — it misses bare names, function names, strings, comments
+- Run `go build ./...` after each rename wave before moving on
+- When updating callers, check if other packages have their own method with the same name and different semantics — don't touch them without user approval
+
+## Edits
+
+- After editing a source file, verify it wasn't accidentally truncated
+- Prefer small targeted edits over large multi-line replacements
+
+## Constraints
+
+- Ask before relaxing any established constraint or convention
+- Ask before introducing new patterns, helpers, or abstractions
+- Match the style of surrounding code exactly

--- a/.agent/docs/workflow.md
+++ b/.agent/docs/workflow.md
@@ -16,3 +16,9 @@
 - Ask before relaxing any established constraint or convention
 - Ask before introducing new patterns, helpers, or abstractions
 - Match the style of surrounding code exactly
+
+## Comments
+
+- Type and package-level comments state **what the type is**, not how its methods work — method names go stale
+- Do not put usage guidance ("Use X to do Y") or examples in type definition comments; those belong in method godocs or external documentation
+- Method comments should be one line where possible; omit anything already obvious from the signature

--- a/.agent/plans/signal-labels-api-cleanup.plan.md
+++ b/.agent/plans/signal-labels-api-cleanup.plan.md
@@ -1,0 +1,131 @@
+# Signal & Labels Package API Cleanup
+
+## Scope
+Only `signal` and `labels` packages get new API. Other packages are adapted (compilation fixes, no public API changes).
+
+---
+
+## signal package
+
+### signal/signal.go
+- Add godoc on `cloneForMutation` / `cloneSignal` documenting the shallow-payload contract:
+  payload is shallow-copied; mutable reference types (map, slice, pointer) are shared across
+  derived signals. Users must treat payload as immutable once placed in a signal.
+
+### signal/types.go
+- Add `Reducer func(acc *Signal, s *Signal) *Signal`
+- Add `PayloadReducer func(acc any, payload any) any`
+
+### signal/group.go
+
+| Change | Detail |
+|---|---|
+| Fix `Every` (was `AllMatch`) vacuous truth | Empty group → `true` |
+| Fix `Filter` capacity hint | `make(Signals, 0, len(g.signals))` |
+| Fix `Map` pointer aliasing | After `result := s.Map(m)`, if `result == s` then `result = cloneSignal(s)` |
+| Rename `AnyMatch` → `Any` | |
+| Rename `AllMatch` → `Every` | No conflict — `All()` stays as-is |
+| Rename `CountMatch` → `Count` | |
+| Rename `AddFromPayloads` → `AddPayloads` | Shorter, symmetric with `Add` |
+| Remove `Without` | Replaced by `Filter(Not(p))` with predicate combinators |
+| Add `Last() *Signal` | Symmetric with `First`; slices are ordered |
+| Add `Join(other *Group) *Group` | Merges two groups; receiver unchanged |
+| Add `Contains(s *Signal) bool` | Pointer identity check |
+| Add `ContainsPayload(payload any) bool` | Uses `==`; comparable types only; documented |
+| Add `ContainsPayloadFunc(eq func(any) bool) bool` | For non-comparable types |
+| Add `Reduce(initial *Signal, fn Reducer) *Signal` | Full signal accumulation |
+| Add `ReducePayloads(initial any, fn PayloadReducer) any` | Payload-only convenience |
+
+### signal/predicates.go (new file)
+
+Combinators:
+```go
+func Not(p Predicate) Predicate
+func And(p1, p2 Predicate) Predicate
+func Or(p1, p2 Predicate) Predicate
+```
+
+Label-aware constructors (return a Predicate):
+```go
+func HasLabel(name string) Predicate
+func LabelEquals(name, value string) Predicate
+func LabelContains(name, substr string) Predicate
+func HasAllLabels(names ...string) Predicate
+func HasAnyLabel(names ...string) Predicate
+```
+
+Usage examples:
+```go
+g.Filter(And(LabelEquals("env", "prod"), Not(HasLabel("skip"))))
+g.Filter(Or(LabelContains("tag", "urgent"), HasAnyLabel("priority", "critical")))
+```
+
+### signal/group_test.go
+- Rename `AddFromPayloads` → `AddPayloads`
+- Remove `Without` tests; replace usage with `Filter(Not(p))`
+- Rename `AnyMatch` → `Any`, `AllMatch` → `Every`, `CountMatch` → `Count`
+- Update `Every` empty-group test case: `false` → `true`
+- Add tests: `Last`, `Join`, `Contains`, `ContainsPayload`, `ContainsPayloadFunc`, `Reduce`, `ReducePayloads`
+
+### signal/predicates_test.go (new file)
+- Full coverage for all 8 combinator/constructor functions
+
+### signal/immutability_test.go
+- Add case: `Map` with identity mapper verifies no pointer aliasing in output
+
+---
+
+## labels package
+
+### labels/labels.go
+
+| Change | Detail |
+|---|---|
+| Rename `AnyMatch` → `Any` | Also update internal call in `HasAnyFrom` |
+| Rename `AllMatch` → `Every` | Also update internal call in `HasAllFrom` |
+| Rename `CountMatch` → `Count` | |
+| Fix `ValueIs` double lookup | Single: `v, ok := c.labels[label]; return ok && v == value` |
+| Add `Keys() []string` | Returns all label names, sorted for determinism |
+| Add `Values() []string` | Returns all label values, sorted by key for determinism |
+| Add `Merge(other *Collection) *Collection` | New collection; `other` wins on key conflict; non-mutating on both inputs |
+
+Notes:
+- Labels stays **mutable** — cannot change without breaking port.go (out of scope)
+- `Every` vacuous truth is already correct in labels (empty → `true`). No logic change, just rename.
+- `WithoutIf` not added — use `Filter(Not(pred))` style (labels has its own `Filter`)
+
+### labels/labels_test.go
+- Rename all `AnyMatch` → `Any`, `AllMatch` → `Every`, `CountMatch` → `Count` test names and calls
+- Add tests: `Keys`, `Values`, `Merge`
+- Add `ValueIs` edge cases (key exists with empty value, key absent)
+
+---
+
+## Adapting other packages (compilation fixes only, zero public API changes)
+
+These two call sites reference `signal.Group` methods we are renaming:
+
+| File | Line | Change |
+|---|---|---|
+| `integration_tests/component_hooks/basic_test.go` | 129 | `.Signals().AnyMatch(` → `.Signals().Any(` |
+| `port/port_test.go` | 1051 | `.Signals().AllMatch(` → `.Signals().Every(` |
+
+Note: `AnyMatch`/`AllMatch`/`CountMatch` in `cycle`, `component`, and `port` packages are those
+packages' own independent methods on their own types. They are NOT being renamed.
+
+---
+
+## Decisions & rationale (for future reference)
+
+- **No generics** — FBP requires mixed-type signal groups; `any` is the right fit
+- **No deep-copy mode on ports** — signals shared by pointer is fmesh design; users treat payload as immutable
+- **No Clone() on Signal** — all label-mutating methods already return new signals (copy-on-write)
+- **No text DSL for label queries** — predicate combinators are type-safe and composable
+- **Labels stays mutable** — port.go uses labels mutably; we cannot change port's public API
+- **Without removed from signal.Group** — `Filter(Not(p))` with combinators is cleaner
+- **WithoutIf not added to labels** — same reasoning
+- **Every (not All) for AllMatch** — `All()` is already taken (returns all signals)
+- **Join (not Concat/Merge) for group merging** — Concat is string-flavored; Join is clean
+- **ContainsPayloadFunc separate method** — no reflect; users pass their own comparator
+- **AllMatch vacuous truth fixed in signal** — empty group returns `true` (standard math semantics)
+- **AllMatch vacuous truth already correct in labels** — loop falls through to `return true`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,201 @@
+# Agent Guide — F-Mesh
+
+This file is the primary reference for AI coding agents working on this repository.
+Read it fully before making any changes.
+
+---
+
+## What this project is
+
+F-Mesh is a **Flow-Based Programming (FBP) framework** for Go.
+Applications are built as directed graphs of independent **components** connected by **ports** and **pipes**.
+Data packets called **signals** flow through the graph.
+Execution runs in discrete synchronized **cycles** (ticks); all eligible components run concurrently per cycle.
+
+The framework is **not optimized for performance**. It prioritizes **simplicity, readability, and clean API design**.
+
+---
+
+## Repository layout
+
+```
+fmesh.go              # Mesh orchestrator: Run() loop, cycle management, mustStop()
+runtime.go            # RuntimeInfo: start/stop time, cycle list
+config.go             # Configurable behavior: error strategy, cycle/time limits
+hooks.go              # Mesh-level lifecycle hooks
+errors.go             # Mesh-level error definitions
+
+signal/               # Signal (data packet) and Group (ordered collection)
+labels/               # Key-value string label collections (attached to signals or ports/components)
+port/                 # Port, pipe connections, port collections and groups
+component/            # Component, activation logic, state, I/O helpers
+cycle/                # Cycle struct and ordered collection
+hook/                 # Generic ordered callback group (reusable across packages)
+integration_tests/    # End-to-end scenario tests (computation, piping, hooks, state, etc.)
+.agent/plans/         # Implementation plans for pending work — check here before starting
+```
+
+---
+
+## Core concepts and their types
+
+| Concept | Type | Package |
+|---|---|---|
+| Data packet | `*Signal` | `signal` |
+| Ordered signal collection | `*signal.Group` | `signal` |
+| Key-value metadata | `*labels.Collection` | `labels` |
+| Component processing unit | `*component.Component` | `component` |
+| Data endpoint on component | `*port.Port` | `port` |
+| Directed connection between ports | pipe (output→input via `PipeTo`) | `port` |
+| One execution tick | `*cycle.Cycle` | `cycle` |
+| Ordered cycle collection | `*cycle.Group` | `cycle` |
+| Lifecycle callback list | `*hook.Group` | `hook` |
+
+---
+
+## Design principles — follow these at all times
+
+### 1. Signals are immutable (copy-on-write)
+All mutating methods on `*Signal` (e.g. `AddLabel`, `SetLabels`, `MapPayload`) return a **new** `*Signal`.
+The receiver is never modified. Never add methods to `*Signal` that mutate in place.
+
+**Payload is shallow-copied.** If the payload is a mutable reference type (map, slice, pointer to struct),
+the user is responsible for treating it as immutable once placed in a signal. The framework does not
+and cannot enforce deep immutability on `any` payloads.
+
+### 2. Groups are immutable (copy-on-write)
+All mutating methods on `*signal.Group` (e.g. `Add`, `Filter`, `Map`) return a **new** `*Group`.
+The internal `[]*Signal` slice is cloned; individual `*Signal` pointers are shared (safe because signals are immutable).
+
+### 3. Chainable error pattern
+All builder/fluent methods store errors in a `chainableErr` field instead of returning `(T, error)`.
+The chain short-circuits: if `HasChainableErr()` is true, methods are no-ops and return `self`.
+This applies to `Signal`, `signal.Group`, `labels.Collection`, `Port`, and all other chainable types.
+
+### 4. Labels are mutable
+`labels.Collection` mutates in place (`Add`, `AddMany`, `Without`, `Clear`).
+This is intentional — `port.Port` and `component.Component` hold labels as mutable state.
+Do NOT make `labels.Collection` copy-on-write; it would break port and component packages.
+
+### 5. Fan-out uses pointer sharing
+When an output port fans out to multiple input ports, the same `*Signal` pointers are forwarded to all destinations.
+This is a deliberate design choice — do not add deep-copy logic to `ForwardSignals` or `Flush`.
+Users must treat signal payloads as immutable.
+
+### 6. No generics
+The signal/group API uses `any` for payload. This is intentional — FBP requires mixed-type signal flows
+in a single group. Do not introduce generics into `signal` or `labels` packages.
+
+### 7. No `reflect`
+Do not use `reflect` anywhere in the framework. If a method needs to handle non-comparable types,
+provide a `Func` variant that accepts a user-supplied comparator (e.g. `ContainsPayloadFunc`).
+
+---
+
+## Package-level rules
+
+### `signal` package
+- `Signal.payload` is `[]any{value}` — a single-element slice to allow `nil` as a valid payload
+- `cloneForMutation()` is the internal helper for copy-on-write; always use it in mutating methods
+- Predicate combinators (`Not`, `And`, `Or`) and label-aware constructors (`HasLabel`, `LabelEquals`, etc.)
+  live in `signal/predicates.go` — use these instead of inline closures wherever possible
+- `signal.Group` is ordered (backed by a slice); `First()` and `Last()` are meaningful
+
+### `labels` package
+- Backed by `map[string]string` — iteration order is not guaranteed; `Keys()` and `Values()` return sorted slices
+- `Merge(other)` returns a new collection (non-mutating); all other write methods mutate in place
+- `Every(pred)` returns `true` for an empty collection (vacuous truth) — this is correct and intentional
+
+### `port` package
+- `Port.Signals()` returns `*signal.Group` — the signal buffer
+- `Flush()` fans out signals to all piped ports then clears the source port
+- `PipeTo` only connects output→input; `validatePipe` enforces this
+- Port labels are mutable (use `labels.Collection` directly)
+
+### `component` package
+- `ActivationFunc` is `func(*Component) error`
+- `MaybeActivate()` decides readiness and runs the activation function
+- `State` is `map[string]any` — persistent across cycles, intentionally untyped
+- Components hold `*port.Collection` for inputs and outputs
+
+### `cycle` package
+- `cycle.Group` has its own `AnyMatch`/`AllMatch`/`CountMatch` — these are separate from `signal.Group`'s methods
+  and are NOT renamed when signal/labels methods are renamed
+
+### `component` and `port` packages
+- Both have their own `AnyMatch`/`AllMatch`/`CountMatch` on their collection types
+- These are independent of signal/labels and follow their own naming evolution
+
+---
+
+## Naming conventions
+
+| Pattern | Convention |
+|---|---|
+| Predicate matching (signal.Group, labels.Collection) | `Any(p)`, `Every(p)`, `Count(p)` |
+| Predicate matching (cycle, port, component collections) | `AnyMatch`, `AllMatch`, `CountMatch` (legacy, not yet renamed) |
+| Add items to a group | `Add(signals...)`, `AddPayloads(payloads...)` |
+| Merge two groups | `Join(other)` |
+| Transform all items | `Map(mapper)`, `MapPayloads(mapper)` |
+| Transform matching items | `MapIf(pred, mapper)`, `MapPayloadsIf(pred, mapper)` |
+| Iterate with side effects | `ForEach(action)`, `ForEachIf(pred, action)` |
+| Remove items | `Filter(Not(p))` — do not add `Without` convenience wrappers |
+| Accumulate | `Reduce(initial, fn)`, `ReducePayloads(initial, fn)` |
+
+---
+
+## Testing conventions
+
+- Unit tests live alongside source files (`*_test.go` in the same package, using `package signal` not `package signal_test`)
+- Integration tests live in `integration_tests/` organized by scenario
+- Use `github.com/stretchr/testify/assert` and `require`
+- Table-driven tests are the standard pattern — always prefer them over repeated inline calls
+- Immutability must be tested explicitly — see `signal/immutability_test.go` as the reference pattern
+- A `mustAll()` helper pattern (panics on error, for test setup) is acceptable in `_test.go` files
+
+### Do not invent test helpers
+**Never create helper functions** (e.g. `check(t, ...)`, `assertNilPayload(t, ...)`) just to reduce
+repetition inside a single test. Use plain `assert`/`require` calls directly. If a subtests-based
+structure avoids repetition, use `t.Run(name, func(t *testing.T){...})` with inline assertions.
+The only exception is a `mustXxx()` panic-on-error helper used strictly for **test setup** (building
+fixtures), not for assertions. Ask the user before introducing any new test helper.
+
+---
+
+## How to verify your work
+
+```bash
+make test    # go test ./...
+make lint    # golangci-lint run ./...
+make fmt     # go fmt ./...
+```
+
+All three must pass before any change is considered done.
+The linter is strict — check `.golangci.yml` for enabled rules.
+Key linters to be aware of: `errcheck`, `govet` (with shadow), `prealloc`, `dupl`, `testifylint`.
+
+---
+
+## Git rules — non-negotiable
+
+- **Never** run `git commit` on behalf of the user
+- **Never** run `git push` on behalf of the user
+- **Never** amend, rebase, or otherwise rewrite history
+- Stage and show diffs freely; let the user decide when to commit
+
+---
+
+## Before starting any task
+
+1. Check `.agent/plans/` for an existing plan covering the work
+2. If a plan exists, follow it; if scope has changed, update the plan file first
+3. Run `make test` to confirm the baseline is green before making changes
+4. Understand which packages are in scope — changing a package's **public API** requires explicit approval;
+   adapting internal callers to renamed/removed methods does not
+
+---
+
+## Active branch context
+
+Branch `signal_immutability` — work in progress on signal/labels API cleanup.
+See `.agent/plans/signal-labels-api-cleanup.plan.md` for the full implementation plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,201 +1,40 @@
 # Agent Guide — F-Mesh
 
-This file is the primary reference for AI coding agents working on this repository.
-Read it fully before making any changes.
+F-Mesh is a Flow-Based Programming (FBP) framework for Go. Apps are directed graphs of **components** connected by **ports** and **pipes**. Data flows as **signals**. Execution runs in discrete synchronized **cycles**; all eligible components run concurrently per cycle.
 
----
+Priority: **simplicity and clean API** — not performance.
 
-## What this project is
-
-F-Mesh is a **Flow-Based Programming (FBP) framework** for Go.
-Applications are built as directed graphs of independent **components** connected by **ports** and **pipes**.
-Data packets called **signals** flow through the graph.
-Execution runs in discrete synchronized **cycles** (ticks); all eligible components run concurrently per cycle.
-
-The framework is **not optimized for performance**. It prioritizes **simplicity, readability, and clean API design**.
-
----
-
-## Repository layout
+## Layout
 
 ```
-fmesh.go              # Mesh orchestrator: Run() loop, cycle management, mustStop()
-runtime.go            # RuntimeInfo: start/stop time, cycle list
-config.go             # Configurable behavior: error strategy, cycle/time limits
-hooks.go              # Mesh-level lifecycle hooks
-errors.go             # Mesh-level error definitions
-
-signal/               # Signal (data packet) and Group (ordered collection)
-labels/               # Key-value string label collections (attached to signals or ports/components)
-port/                 # Port, pipe connections, port collections and groups
-component/            # Component, activation logic, state, I/O helpers
-cycle/                # Cycle struct and ordered collection
-hook/                 # Generic ordered callback group (reusable across packages)
-integration_tests/    # End-to-end scenario tests (computation, piping, hooks, state, etc.)
-.agent/plans/         # Implementation plans for pending work — check here before starting
+fmesh.go / runtime.go / config.go / hooks.go / errors.go
+signal/        port/          component/     cycle/
+labels/        hook/          integration_tests/
+.agent/plans/  (historical)   .agent/docs/   (reference)
 ```
 
----
+## Reference docs
 
-## Core concepts and their types
+- [Design](.agent/docs/design.md) — architecture, invariants, package rules
+- [Naming](.agent/docs/naming.md) — CoW vs mutating, method naming
+- [Testing](.agent/docs/testing.md) — style, what to cover
+- [Workflow](.agent/docs/workflow.md) — how to work safely
 
-| Concept | Type | Package |
-|---|---|---|
-| Data packet | `*Signal` | `signal` |
-| Ordered signal collection | `*signal.Group` | `signal` |
-| Key-value metadata | `*labels.Collection` | `labels` |
-| Component processing unit | `*component.Component` | `component` |
-| Data endpoint on component | `*port.Port` | `port` |
-| Directed connection between ports | pipe (output→input via `PipeTo`) | `port` |
-| One execution tick | `*cycle.Cycle` | `cycle` |
-| Ordered cycle collection | `*cycle.Group` | `cycle` |
-| Lifecycle callback list | `*hook.Group` | `hook` |
+## Before starting
 
----
+Run `make test` — confirm baseline is green.
 
-## Design principles — follow these at all times
+Public API changes require explicit user approval. Adapting callers does not.
 
-### 1. Signals are immutable (copy-on-write)
-All mutating methods on `*Signal` (e.g. `AddLabel`, `SetLabels`, `MapPayload`) return a **new** `*Signal`.
-The receiver is never modified. Never add methods to `*Signal` that mutate in place.
-
-**Payload is shallow-copied.** If the payload is a mutable reference type (map, slice, pointer to struct),
-the user is responsible for treating it as immutable once placed in a signal. The framework does not
-and cannot enforce deep immutability on `any` payloads.
-
-### 2. Groups are immutable (copy-on-write)
-All mutating methods on `*signal.Group` (e.g. `Add`, `Filter`, `Map`) return a **new** `*Group`.
-The internal `[]*Signal` slice is cloned; individual `*Signal` pointers are shared (safe because signals are immutable).
-
-### 3. Chainable error pattern
-All builder/fluent methods store errors in a `chainableErr` field instead of returning `(T, error)`.
-The chain short-circuits: if `HasChainableErr()` is true, methods are no-ops and return `self`.
-This applies to `Signal`, `signal.Group`, `labels.Collection`, `Port`, and all other chainable types.
-
-### 4. Labels are mutable
-`labels.Collection` mutates in place (`Add`, `AddMany`, `Without`, `Clear`).
-This is intentional — `port.Port` and `component.Component` hold labels as mutable state.
-Do NOT make `labels.Collection` copy-on-write; it would break port and component packages.
-
-### 5. Fan-out uses pointer sharing
-When an output port fans out to multiple input ports, the same `*Signal` pointers are forwarded to all destinations.
-This is a deliberate design choice — do not add deep-copy logic to `ForwardSignals` or `Flush`.
-Users must treat signal payloads as immutable.
-
-### 6. No generics
-The signal/group API uses `any` for payload. This is intentional — FBP requires mixed-type signal flows
-in a single group. Do not introduce generics into `signal` or `labels` packages.
-
-### 7. No `reflect`
-Do not use `reflect` anywhere in the framework. If a method needs to handle non-comparable types,
-provide a `Func` variant that accepts a user-supplied comparator (e.g. `ContainsPayloadFunc`).
-
----
-
-## Package-level rules
-
-### `signal` package
-- `Signal.payload` is `[]any{value}` — a single-element slice to allow `nil` as a valid payload
-- `cloneForMutation()` is the internal helper for copy-on-write; always use it in mutating methods
-- Predicate combinators (`Not`, `And`, `Or`) and label-aware constructors (`HasLabel`, `LabelEquals`, etc.)
-  live in `signal/predicates.go` — use these instead of inline closures wherever possible
-- `signal.Group` is ordered (backed by a slice); `First()` and `Last()` are meaningful
-
-### `labels` package
-- Backed by `map[string]string` — iteration order is not guaranteed; `Keys()` and `Values()` return sorted slices
-- `Merge(other)` returns a new collection (non-mutating); all other write methods mutate in place
-- `Every(pred)` returns `true` for an empty collection (vacuous truth) — this is correct and intentional
-
-### `port` package
-- `Port.Signals()` returns `*signal.Group` — the signal buffer
-- `Flush()` fans out signals to all piped ports then clears the source port
-- `PipeTo` only connects output→input; `validatePipe` enforces this
-- Port labels are mutable (use `labels.Collection` directly)
-
-### `component` package
-- `ActivationFunc` is `func(*Component) error`
-- `MaybeActivate()` decides readiness and runs the activation function
-- `State` is `map[string]any` — persistent across cycles, intentionally untyped
-- Components hold `*port.Collection` for inputs and outputs
-
-### `cycle` package
-- `cycle.Group` has its own `AnyMatch`/`AllMatch`/`CountMatch` — these are separate from `signal.Group`'s methods
-  and are NOT renamed when signal/labels methods are renamed
-
-### `component` and `port` packages
-- Both have their own `AnyMatch`/`AllMatch`/`CountMatch` on their collection types
-- These are independent of signal/labels and follow their own naming evolution
-
----
-
-## Naming conventions
-
-| Pattern | Convention |
-|---|---|
-| Predicate matching (signal.Group, labels.Collection) | `Any(p)`, `Every(p)`, `Count(p)` |
-| Predicate matching (cycle, port, component collections) | `AnyMatch`, `AllMatch`, `CountMatch` (legacy, not yet renamed) |
-| Add items to a group | `Add(signals...)`, `AddPayloads(payloads...)` |
-| Merge two groups | `Join(other)` |
-| Transform all items | `Map(mapper)`, `MapPayloads(mapper)` |
-| Transform matching items | `MapIf(pred, mapper)`, `MapPayloadsIf(pred, mapper)` |
-| Iterate with side effects | `ForEach(action)`, `ForEachIf(pred, action)` |
-| Remove items | `Filter(Not(p))` — do not add `Without` convenience wrappers |
-| Accumulate | `Reduce(initial, fn)`, `ReducePayloads(initial, fn)` |
-
----
-
-## Testing conventions
-
-- Unit tests live alongside source files (`*_test.go` in the same package, using `package signal` not `package signal_test`)
-- Integration tests live in `integration_tests/` organized by scenario
-- Use `github.com/stretchr/testify/assert` and `require`
-- Table-driven tests are the standard pattern — always prefer them over repeated inline calls
-- Immutability must be tested explicitly — see `signal/immutability_test.go` as the reference pattern
-- A `mustAll()` helper pattern (panics on error, for test setup) is acceptable in `_test.go` files
-
-### Do not invent test helpers
-**Never create helper functions** (e.g. `check(t, ...)`, `assertNilPayload(t, ...)`) just to reduce
-repetition inside a single test. Use plain `assert`/`require` calls directly. If a subtests-based
-structure avoids repetition, use `t.Run(name, func(t *testing.T){...})` with inline assertions.
-The only exception is a `mustXxx()` panic-on-error helper used strictly for **test setup** (building
-fixtures), not for assertions. Ask the user before introducing any new test helper.
-
----
-
-## How to verify your work
+## Verify
 
 ```bash
-make test    # go test ./...
-make lint    # golangci-lint run ./...
-make fmt     # go fmt ./...
+make test && make lint && make fmt
 ```
 
-All three must pass before any change is considered done.
-The linter is strict — check `.golangci.yml` for enabled rules.
-Key linters to be aware of: `errcheck`, `govet` (with shadow), `prealloc`, `dupl`, `testifylint`.
+Key linters: `errcheck`, `govet` (shadow), `prealloc`, `dupl`, `testifylint`.
 
----
+## Git
 
-## Git rules — non-negotiable
-
-- **Never** run `git commit` on behalf of the user
-- **Never** run `git push` on behalf of the user
-- **Never** amend, rebase, or otherwise rewrite history
-- Stage and show diffs freely; let the user decide when to commit
-
----
-
-## Before starting any task
-
-1. Check `.agent/plans/` for an existing plan covering the work
-2. If a plan exists, follow it; if scope has changed, update the plan file first
-3. Run `make test` to confirm the baseline is green before making changes
-4. Understand which packages are in scope — changing a package's **public API** requires explicit approval;
-   adapting internal callers to renamed/removed methods does not
-
----
-
-## Active branch context
-
-Branch `signal_immutability` — work in progress on signal/labels API cleanup.
-See `.agent/plans/signal-labels-api-cleanup.plan.md` for the full implementation plan.
+- Never `git commit` or `git push`
+- Never amend or rewrite history

--- a/component/component.go
+++ b/component/component.go
@@ -49,7 +49,7 @@ func (c *Component) Description() string {
 	return c.description
 }
 
-// WithDescription sets the component description and returns the component for chaining.
+// WithDescription sets the component description.
 func (c *Component) WithDescription(description string) *Component {
 	if c.HasChainableErr() {
 		return c
@@ -67,7 +67,7 @@ func (c *Component) Labels() *labels.Collection {
 	return c.labels
 }
 
-// SetLabels replaces all labels and returns the component for chaining.
+// SetLabels replaces all labels.
 func (c *Component) SetLabels(labelMap labels.Map) *Component {
 	if c.HasChainableErr() {
 		return c
@@ -76,7 +76,7 @@ func (c *Component) SetLabels(labelMap labels.Map) *Component {
 	return c
 }
 
-// AddLabels adds or updates labels and returns the component for chaining.
+// AddLabels adds or updates labels.
 func (c *Component) AddLabels(labelMap labels.Map) *Component {
 	if c.HasChainableErr() {
 		return c
@@ -85,7 +85,7 @@ func (c *Component) AddLabels(labelMap labels.Map) *Component {
 	return c
 }
 
-// AddLabel adds or updates a single label and returns the component for chaining.
+// AddLabel adds or updates a single label.
 func (c *Component) AddLabel(name, value string) *Component {
 	if c.HasChainableErr() {
 		return c
@@ -94,7 +94,7 @@ func (c *Component) AddLabel(name, value string) *Component {
 	return c
 }
 
-// ClearLabels removes all labels and returns the component for chaining.
+// ClearLabels removes all labels.
 func (c *Component) ClearLabels() *Component {
 	if c.HasChainableErr() {
 		return c
@@ -103,12 +103,12 @@ func (c *Component) ClearLabels() *Component {
 	return c
 }
 
-// WithoutLabels removes specific labels and returns the component for chaining.
-func (c *Component) WithoutLabels(names ...string) *Component {
+// RemoveLabels removes specific labels.
+func (c *Component) RemoveLabels(names ...string) *Component {
 	if c.HasChainableErr() {
 		return c
 	}
-	c.labels.Without(names...)
+	c.labels.Remove(names...)
 	return c
 }
 
@@ -180,13 +180,7 @@ func (c *Component) WithLogger(logger *log.Logger) *Component {
 	return c
 }
 
-// Logger returns the component's logger for debugging and monitoring.
-// Use this to log information during component activation.
-//
-// Example (in activation function):
-//
-//	this.Logger().Printf("Processing %d items", count)
-//	this.Logger().Println("Validation completed successfully")
+// Logger returns the component's logger.
 func (c *Component) Logger() *log.Logger {
 	return c.logger
 }

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -274,7 +274,7 @@ func TestComponent_ClearLabels(t *testing.T) {
 	}
 }
 
-func TestComponent_WithoutLabels(t *testing.T) {
+func TestComponent_RemoveLabels(t *testing.T) {
 	tests := []struct {
 		name           string
 		component      *Component
@@ -317,7 +317,7 @@ func TestComponent_WithoutLabels(t *testing.T) {
 			component:      New("c1").AddLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}),
 			labelsToRemove: []string{"k1"},
 			assertions: func(t *testing.T, component *Component) {
-				result := component.WithoutLabels("k2").AddLabel("k4", "v4")
+				result := component.RemoveLabels("k2").AddLabel("k4", "v4")
 				assert.Equal(t, 2, result.Labels().Len())
 				assert.False(t, result.Labels().Has("k1"))
 				assert.False(t, result.Labels().Has("k2"))
@@ -328,7 +328,7 @@ func TestComponent_WithoutLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			componentAfter := tt.component.WithoutLabels(tt.labelsToRemove...)
+			componentAfter := tt.component.RemoveLabels(tt.labelsToRemove...)
 			if tt.assertions != nil {
 				tt.assertions(t, componentAfter)
 			}
@@ -416,10 +416,10 @@ func TestComponent_Chainability(t *testing.T) {
 		assert.True(t, c.Labels().ValueIs("k3", "v3"))
 	})
 
-	t.Run("WithoutLabels removes specific labels", func(t *testing.T) {
+	t.Run("RemoveLabels removes specific labels", func(t *testing.T) {
 		c := New("c1").
 			AddLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}).
-			WithoutLabels("k1", "k2").
+			RemoveLabels("k1", "k2").
 			AddLabel("k4", "v4")
 
 		assert.Equal(t, 2, c.Labels().Len())

--- a/integration_tests/chainability/chainability_test.go
+++ b/integration_tests/chainability/chainability_test.go
@@ -48,13 +48,13 @@ func TestChainability_CrossPackage(t *testing.T) {
 
 	t.Run("signal with multiple label operations", func(t *testing.T) {
 		s := signal.New("payload").
-			AddLabel("source", "api").
-			AddLabels(labels.Map{"priority": "high", "retry": "true"}).
-			SetLabels(labels.Map{"final": "label"}) // Reset
+			WithLabel("source", "api").
+			WithLabels(labels.Map{"priority": "high", "retry": "true"}).
+			WithOnlyLabels(labels.Map{"final": "label"}) // Reset
 
 		assert.Equal(t, 1, s.Labels().Len())
 		assert.True(t, s.Labels().ValueIs("final", "label"))
-		assert.False(t, s.Labels().Has("source"), "wiped by SetLabels")
+		assert.False(t, s.Labels().Has("source"), "wiped by WithOnlyLabels")
 	})
 
 	t.Run("component with label cleanup", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestChainability_CrossPackage(t *testing.T) {
 			}).
 			AddInputs("tasks").
 			AddOutputs("results").
-			WithoutLabels("debug", "trace-id") // Clean up temporary labels
+			RemoveLabels("debug", "trace-id") // Clean up temporary labels
 
 		assert.Equal(t, 2, c.Labels().Len(), "should have only permanent labels")
 		assert.True(t, c.Labels().Has("env"))
@@ -106,16 +106,16 @@ func TestChainability_CrossPackage(t *testing.T) {
 	t.Run("signal filtering and relabeling", func(t *testing.T) {
 		// Signal with metadata that gets filtered and relabeled
 		s := signal.New(map[string]any{"data": "value"}).
-			AddLabels(labels.Map{
+			WithLabels(labels.Map{
 				"source":    "api",
 				"priority":  "low",
 				"timestamp": "2024-01-01",
 				"temp":      "metadata",
 			}).
-			WithoutLabels("temp").        // Remove temporary metadata
-			WithoutLabels("priority").    // Remove old priority
-			AddLabel("priority", "high"). // Set new priority
-			AddLabel("processed", "true")
+			WithoutLabels("temp").         // Remove temporary metadata
+			WithoutLabels("priority").     // Remove old priority
+			WithLabel("priority", "high"). // Set new priority
+			WithLabel("processed", "true")
 
 		assert.Equal(t, 4, s.Labels().Len())
 		assert.False(t, s.Labels().Has("temp"))
@@ -140,9 +140,9 @@ func TestChainability_CrossPackage(t *testing.T) {
 				"verbose":  "true",
 				"trace-id": "xyz789",
 			}).
-			WithoutLabels("debug", "verbose", "trace-id"). // Remove all debug labels
-			AddLabel("env", "prod").                       // Update env to prod
-			AddLabel("deployed", "true")                   // Add deployment marker
+			RemoveLabels("debug", "verbose", "trace-id"). // Remove all debug labels
+			AddLabel("env", "prod").                      // Update env to prod
+			AddLabel("deployed", "true")                  // Add deployment marker
 
 		assert.Equal(t, 3, c.Labels().Len())
 		assert.True(t, c.Labels().ValueIs("env", "prod"), "env updated to prod")
@@ -156,20 +156,20 @@ func TestChainability_CrossPackage(t *testing.T) {
 	t.Run("port and signal label coordination", func(t *testing.T) {
 		// Port and signals with coordinated label management
 		s1 := signal.New(1).
-			AddLabels(labels.Map{"priority": "high", "source": "user"}).
+			WithLabels(labels.Map{"priority": "high", "source": "user"}).
 			WithoutLabels("source").
-			AddLabel("source", "validated")
+			WithLabel("source", "validated")
 
 		s2 := signal.New(2).
-			AddLabels(labels.Map{"priority": "low", "source": "batch"}).
-			ClearLabels().
-			AddLabels(labels.Map{"priority": "high", "source": "validated"})
+			WithLabels(labels.Map{"priority": "low", "source": "batch"}).
+			WithNoLabels().
+			WithLabels(labels.Map{"priority": "high", "source": "validated"})
 
 		p := port.NewInput("validated-input").
 			AddLabel("type", "input").
 			PutSignals(s1, s2).
 			AddLabel("count", "2").
-			WithoutLabels("type") // Remove type
+			RemoveLabels("type") // Remove type
 
 		assert.Equal(t, 2, p.Signals().Len())
 		assert.Equal(t, 1, p.Labels().Len())

--- a/integration_tests/component_hooks/basic_test.go
+++ b/integration_tests/component_hooks/basic_test.go
@@ -126,7 +126,7 @@ func TestComponentHooks_OnWaitingForInputs(t *testing.T) {
 		}).
 		WithActivationFunc(func(c *component.Component) error {
 			// Wait for config input
-			if !c.InputByName("config").Signals().AnyMatch(func(s *signal.Signal) bool { return true }) {
+			if !c.InputByName("config").Signals().Any(func(s *signal.Signal) bool { return true }) {
 				return component.ErrWaitingForInputs
 			}
 			return nil

--- a/integration_tests/labels/transform_test.go
+++ b/integration_tests/labels/transform_test.go
@@ -16,7 +16,7 @@ import (
 func Test_LabelTransformation(t *testing.T) {
 	t.Run("normalize label keys to uppercase", func(t *testing.T) {
 		// Scenario: You receive signals with mixed-case labels and want to normalize them
-		sig := signal.New(100).SetLabels(labels.Map{
+		sig := signal.New(100).WithOnlyLabels(labels.Map{
 			"env":    "production",
 			"Region": "us-east",
 			"Tier":   "backend",
@@ -56,7 +56,7 @@ func Test_LabelTransformation(t *testing.T) {
 
 	t.Run("add prefix to label values", func(t *testing.T) {
 		// Scenario: You want to mark all label values as coming from a specific source
-		sig := signal.New("data").SetLabels(labels.Map{
+		sig := signal.New("data").WithOnlyLabels(labels.Map{
 			"source": "api",
 			"format": "json",
 		})
@@ -72,7 +72,7 @@ func Test_LabelTransformation(t *testing.T) {
 
 	t.Run("convert labels to debug format", func(t *testing.T) {
 		// Scenario: You want to wrap all label values in brackets for debugging
-		sig := signal.New(42).SetLabels(labels.Map{
+		sig := signal.New(42).WithOnlyLabels(labels.Map{
 			"id":   "123",
 			"name": "test",
 		})
@@ -110,7 +110,7 @@ func Test_LabelTransformation(t *testing.T) {
 						return err
 					}
 
-					newSignal := signal.New(sig.PayloadOrNil()).SetLabels(labelsMap)
+					newSignal := signal.New(sig.PayloadOrNil()).WithOnlyLabels(labelsMap)
 					return outPort.PutSignals(newSignal).ChainableErr()
 				})
 
@@ -121,7 +121,7 @@ func Test_LabelTransformation(t *testing.T) {
 
 		// Input signal with mixed-case labels
 		fm.ComponentByName("normalizer").InputByName("in").PutSignals(
-			signal.New(100).SetLabels(labels.Map{
+			signal.New(100).WithOnlyLabels(labels.Map{
 				"ENV":    "prod",
 				"Region": "us-west",
 				"TIER":   "frontend",
@@ -147,7 +147,7 @@ func Test_LabelTransformation(t *testing.T) {
 
 	t.Run("chain Map with Filter", func(t *testing.T) {
 		// Scenario: Transform labels and then filter them
-		sig := signal.New("data").SetLabels(labels.Map{
+		sig := signal.New("data").WithOnlyLabels(labels.Map{
 			"app.version": "1.0",
 			"app.type":    "service",
 			"sys.cpu":     "high",

--- a/integration_tests/piping/fan_out_concurrency_integration_test.go
+++ b/integration_tests/piping/fan_out_concurrency_integration_test.go
@@ -24,7 +24,7 @@ func TestFanOut_threeConsumers_seeSameSignalPointer(t *testing.T) {
 		AddInputs("start").
 		AddOutputs("o1").
 		WithActivationFunc(func(this *component.Component) error {
-			this.OutputByName("o1").PutSignals(signal.New(42).AddLabel("route", "fan"))
+			this.OutputByName("o1").PutSignals(signal.New(42).WithLabel("route", "fan"))
 			return nil
 		})
 
@@ -78,7 +78,7 @@ func TestFanOut_sharedSignal_parallelStress_completes(t *testing.T) {
 		AddInputs("start").
 		AddOutputs("o1").
 		WithActivationFunc(func(this *component.Component) error {
-			this.OutputByName("o1").PutSignals(signal.New(1).AddLabel("seed", "x"))
+			this.OutputByName("o1").PutSignals(signal.New(1).WithLabel("seed", "x"))
 			return nil
 		})
 
@@ -103,11 +103,11 @@ func TestFanOut_sharedSignal_parallelStress_completes(t *testing.T) {
 					}
 				case 1:
 					for i := range stressIters {
-						shared.AddLabel(fmt.Sprintf("w1_%d", i), "v")
+						shared.WithLabel(fmt.Sprintf("w1_%d", i), "v")
 					}
 				default:
 					for i := range stressIters {
-						shared.AddLabel(fmt.Sprintf("w2_%d", i), "v")
+						shared.WithLabel(fmt.Sprintf("w2_%d", i), "v")
 					}
 				}
 				return port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))

--- a/integration_tests/ports/port_creation_test.go
+++ b/integration_tests/ports/port_creation_test.go
@@ -147,7 +147,7 @@ func Test_PortCreationAndManipulation(t *testing.T) {
 				inputPort.AddLabel("processed", "true")
 
 				// Remove specific labels
-				inputPort.WithoutLabels("version")
+				inputPort.RemoveLabels("version")
 
 				// Update labels
 				inputPort.AddLabels(map[string]string{

--- a/labels/encapsulation_test.go
+++ b/labels/encapsulation_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Contract tests for github.com/hovsep/fmesh#203 (Collection.All must not alias internal map).
+// Contract tests: Collection.All must return a defensive copy of the internal map,
+// not a live reference. The collection itself is mutable by design; this file
+// guards only against callers reaching inside and corrupting internal state.
 
 func TestLabelsCollection_All_returnsDefensiveCopy(t *testing.T) {
 	c := NewCollection().Add("k", "v")

--- a/labels/labels.go
+++ b/labels/labels.go
@@ -6,7 +6,8 @@ import (
 	"slices"
 )
 
-// Collection provides safe access to labels with error handling.
+// Collection is a mutable key-value string store.
+// All write methods modify the receiver in place.
 type Collection struct {
 	chainableErr error
 	labels       Map
@@ -29,8 +30,35 @@ func (c *Collection) All() (Map, error) {
 	return maps.Clone(c.labels), nil
 }
 
-// AllMatch returns true if all labels in the collection satisfy the predicate.
-func (c *Collection) AllMatch(pred LabelPredicate) bool {
+// Keys returns all label names as a sorted slice. The caller owns the returned slice.
+func (c *Collection) Keys() []string {
+	if c.HasChainableErr() {
+		return nil
+	}
+	keys := make([]string, 0, len(c.labels))
+	for k := range c.labels {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// Values returns all label values as a slice sorted by their corresponding key. The caller owns the returned slice.
+func (c *Collection) Values() []string {
+	if c.HasChainableErr() {
+		return nil
+	}
+	keys := c.Keys()
+	values := make([]string, len(keys))
+	for i, k := range keys {
+		values[i] = c.labels[k]
+	}
+	return values
+}
+
+// Every returns true if all labels in the collection satisfy the predicate.
+// Returns true for an empty collection (vacuous truth).
+func (c *Collection) Every(pred LabelPredicate) bool {
 	if c.HasChainableErr() {
 		return false
 	}
@@ -43,8 +71,8 @@ func (c *Collection) AllMatch(pred LabelPredicate) bool {
 	return true
 }
 
-// AnyMatch returns true if any label in the collection satisfies the predicate.
-func (c *Collection) AnyMatch(pred LabelPredicate) bool {
+// Any returns true if any label in the collection satisfies the predicate.
+func (c *Collection) Any(pred LabelPredicate) bool {
 	if c.HasChainableErr() {
 		return false
 	}
@@ -56,8 +84,8 @@ func (c *Collection) AnyMatch(pred LabelPredicate) bool {
 	return false
 }
 
-// CountMatch returns the number of labels that match the predicate.
-func (c *Collection) CountMatch(pred LabelPredicate) int {
+// Count returns the number of labels that match the predicate.
+func (c *Collection) Count(pred LabelPredicate) int {
 	if c.HasChainableErr() {
 		return 0
 	}
@@ -114,8 +142,23 @@ func (c *Collection) AddMany(labels Map) *Collection {
 	return c
 }
 
-// Without removes given labels.
-func (c *Collection) Without(labels ...string) *Collection {
+// Merge returns a new collection containing all labels from both c and other.
+// On key conflict, other's value wins. Neither c nor other is modified.
+func (c *Collection) Merge(other *Collection) *Collection {
+	if c.HasChainableErr() {
+		return NewCollection().WithChainableErr(c.ChainableErr())
+	}
+	if other.HasChainableErr() {
+		return NewCollection().WithChainableErr(other.ChainableErr())
+	}
+	merged := NewCollection()
+	maps.Copy(merged.labels, c.labels)
+	maps.Copy(merged.labels, other.labels)
+	return merged
+}
+
+// Remove deletes given labels.
+func (c *Collection) Remove(labels ...string) *Collection {
 	if c.HasChainableErr() {
 		return c
 	}
@@ -161,17 +204,8 @@ func (c *Collection) ValueIs(label, value string) bool {
 	if c.HasChainableErr() {
 		return false
 	}
-
-	if !c.Has(label) {
-		return false
-	}
-
-	l, err := c.Value(label)
-	if err != nil {
-		return false
-	}
-
-	return l == value
+	v, ok := c.labels[label]
+	return ok && v == value
 }
 
 // Len returns the number of labels.
@@ -248,9 +282,7 @@ func (c *Collection) HasChainableErr() bool {
 	return c.chainableErr != nil
 }
 
-// HasAllFrom returns true if the current collection contains all labels
-// present in the other collection (ignoring values). Returns false if either
-// collection has a chainable error.
+// HasAllFrom returns true if c contains all labels present in other (values ignored).
 func (c *Collection) HasAllFrom(other *Collection) bool {
 	if c.HasChainableErr() || other.HasChainableErr() {
 		return false
@@ -260,14 +292,12 @@ func (c *Collection) HasAllFrom(other *Collection) bool {
 		return false
 	}
 
-	return other.AllMatch(func(label, _ string) bool {
+	return other.Every(func(label, _ string) bool {
 		return c.Has(label)
 	})
 }
 
-// HasAnyFrom returns true if the current collection contains at least one
-// label present in the other collection (ignoring values). Returns false if
-// either collection has a chainable error.
+// HasAnyFrom returns true if c contains at least one label present in other (values ignored).
 func (c *Collection) HasAnyFrom(other *Collection) bool {
 	if c.HasChainableErr() || other.HasChainableErr() {
 		return false
@@ -277,7 +307,7 @@ func (c *Collection) HasAnyFrom(other *Collection) bool {
 		return false
 	}
 
-	return other.AnyMatch(func(label, _ string) bool {
+	return other.Any(func(label, _ string) bool {
 		return c.Has(label)
 	})
 }

--- a/labels/labels_test.go
+++ b/labels/labels_test.go
@@ -10,27 +10,10 @@ import (
 )
 
 func TestLabelsCollection_New(t *testing.T) {
-	tests := []struct {
-		name       string
-		assertions func(t *testing.T, lc *Collection)
-	}{
-		{
-			name: "empty collection",
-			assertions: func(t *testing.T, lc *Collection) {
-				assert.NotNil(t, lc)
-				assert.Equal(t, 0, lc.Len())
-				assert.False(t, lc.HasChainableErr())
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := NewCollection()
-			if tt.assertions != nil {
-				tt.assertions(t, got)
-			}
-		})
-	}
+	c := NewCollection()
+	assert.NotNil(t, c)
+	assert.Equal(t, 0, c.Len())
+	assert.False(t, c.HasChainableErr())
 }
 
 func TestLabelsCollection_Add(t *testing.T) {
@@ -88,7 +71,7 @@ func TestLabelsCollection_Add(t *testing.T) {
 	}
 }
 
-func TestLabelsCollection_WithMany(t *testing.T) {
+func TestLabelsCollection_AddMany(t *testing.T) {
 	tests := []struct {
 		name       string
 		collection *Collection
@@ -134,7 +117,7 @@ func TestLabelsCollection_WithMany(t *testing.T) {
 	}
 }
 
-func TestLabelsCollection_Without(t *testing.T) {
+func TestLabelsCollection_Remove(t *testing.T) {
 	tests := []struct {
 		name       string
 		collection *Collection
@@ -183,7 +166,7 @@ func TestLabelsCollection_Without(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.collection.Without(tt.labels...)
+			result := tt.collection.Remove(tt.labels...)
 			if tt.assertions != nil {
 				tt.assertions(t, result)
 			}
@@ -464,7 +447,7 @@ func TestLabelsCollection_ValueIs(t *testing.T) {
 	}
 }
 
-func TestLabelsCollection_AllMatch(t *testing.T) {
+func TestLabelsCollection_Every(t *testing.T) {
 	tests := []struct {
 		name       string
 		collection *Collection
@@ -518,12 +501,12 @@ func TestLabelsCollection_AllMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.collection.AllMatch(tt.predicate))
+			assert.Equal(t, tt.want, tt.collection.Every(tt.predicate))
 		})
 	}
 }
 
-func TestLabelsCollection_AnyMatch(t *testing.T) {
+func TestLabelsCollection_Any(t *testing.T) {
 	tests := []struct {
 		name       string
 		collection *Collection
@@ -568,7 +551,7 @@ func TestLabelsCollection_AnyMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.collection.AnyMatch(tt.predicate))
+			assert.Equal(t, tt.want, tt.collection.Any(tt.predicate))
 		})
 	}
 }
@@ -769,7 +752,7 @@ func TestLabelsCollection_Chainable(t *testing.T) {
 				"region": "us-east",
 				"zone":   "1a",
 			}).
-			Without("zone")
+			Remove("zone")
 
 		assert.Equal(t, 3, lc.Len())
 		assert.True(t, lc.Has("env"))
@@ -789,10 +772,10 @@ func TestLabelsCollection_Chainable(t *testing.T) {
 		assert.True(t, lc.ValueIs("k3", "v3"))
 	})
 
-	t.Run("Without called twice removes both sets", func(t *testing.T) {
+	t.Run("Remove called twice removes both sets", func(t *testing.T) {
 		lc := NewCollection().AddMany(Map{"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"}).
-			Without("k1", "k2").
-			Without("k3")
+			Remove("k1", "k2").
+			Remove("k3")
 
 		assert.Equal(t, 1, lc.Len())
 		assert.True(t, lc.ValueIs("k4", "v4"))
@@ -823,8 +806,8 @@ func TestLabelsCollection_ErrorHandling(t *testing.T) {
 			assertions: func(t *testing.T, lc *Collection) {
 				assert.False(t, lc.Has("test"))
 				assert.Equal(t, 0, lc.Len())
-				assert.False(t, lc.AllMatch(func(k, v string) bool { return true }))
-				assert.False(t, lc.AnyMatch(func(k, v string) bool { return true }))
+				assert.False(t, lc.Every(func(k, v string) bool { return true }))
+				assert.False(t, lc.Any(func(k, v string) bool { return true }))
 
 				val, err := lc.Value("test")
 				require.Error(t, err)
@@ -947,7 +930,7 @@ func TestLabelsCollection_HasAnyFrom(t *testing.T) {
 	}
 }
 
-func TestLabelsCollection_CountMatch(t *testing.T) {
+func TestLabelsCollection_Count(t *testing.T) {
 	tests := []struct {
 		name       string
 		collection *Collection
@@ -1001,8 +984,105 @@ func TestLabelsCollection_CountMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.collection.CountMatch(tt.pred)
+			got := tt.collection.Count(tt.pred)
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestLabelsCollection_Keys(t *testing.T) {
+	t.Run("returns sorted keys", func(t *testing.T) {
+		c := NewCollection().AddMany(Map{"b": "2", "a": "1", "c": "3"})
+		assert.Equal(t, []string{"a", "b", "c"}, c.Keys())
+	})
+
+	t.Run("empty collection", func(t *testing.T) {
+		assert.Empty(t, NewCollection().Keys())
+	})
+
+	t.Run("chainable error returns nil", func(t *testing.T) {
+		c := NewCollection().WithChainableErr(errors.New("err"))
+		assert.Nil(t, c.Keys())
+	})
+}
+
+func TestLabelsCollection_Values(t *testing.T) {
+	t.Run("returns values sorted by key", func(t *testing.T) {
+		c := NewCollection().AddMany(Map{"b": "beta", "a": "alpha", "c": "gamma"})
+		assert.Equal(t, []string{"alpha", "beta", "gamma"}, c.Values())
+	})
+
+	t.Run("empty collection", func(t *testing.T) {
+		assert.Empty(t, NewCollection().Values())
+	})
+
+	t.Run("chainable error returns nil", func(t *testing.T) {
+		c := NewCollection().WithChainableErr(errors.New("err"))
+		assert.Nil(t, c.Values())
+	})
+}
+
+func TestLabelsCollection_Merge(t *testing.T) {
+	t.Run("merges two collections", func(t *testing.T) {
+		a := NewCollection().AddMany(Map{"x": "1", "y": "2"})
+		b := NewCollection().AddMany(Map{"y": "overridden", "z": "3"})
+		merged := a.Merge(b)
+
+		assert.Equal(t, 3, merged.Len())
+		assert.True(t, merged.ValueIs("x", "1"))
+		assert.True(t, merged.ValueIs("y", "overridden"), "other wins on conflict")
+		assert.True(t, merged.ValueIs("z", "3"))
+	})
+
+	t.Run("neither input is modified", func(t *testing.T) {
+		a := NewCollection().Add("k", "v")
+		b := NewCollection().Add("k", "other")
+		_ = a.Merge(b)
+		assert.True(t, a.ValueIs("k", "v"))
+		assert.True(t, b.ValueIs("k", "other"))
+	})
+
+	t.Run("merge with empty other", func(t *testing.T) {
+		a := NewCollection().Add("k", "v")
+		merged := a.Merge(NewCollection())
+		assert.Equal(t, 1, merged.Len())
+		assert.True(t, merged.ValueIs("k", "v"))
+	})
+
+	t.Run("merge into empty", func(t *testing.T) {
+		b := NewCollection().Add("k", "v")
+		merged := NewCollection().Merge(b)
+		assert.True(t, merged.ValueIs("k", "v"))
+	})
+
+	t.Run("receiver error propagates", func(t *testing.T) {
+		a := NewCollection().WithChainableErr(errors.New("bad"))
+		merged := a.Merge(NewCollection().Add("x", "1"))
+		assert.True(t, merged.HasChainableErr())
+	})
+
+	t.Run("other error propagates", func(t *testing.T) {
+		b := NewCollection().WithChainableErr(errors.New("bad other"))
+		merged := NewCollection().Add("x", "1").Merge(b)
+		assert.True(t, merged.HasChainableErr())
+	})
+}
+
+func TestLabelsCollection_ValueIs_edge_cases(t *testing.T) {
+	t.Run("key exists with empty value", func(t *testing.T) {
+		c := NewCollection().Add("k", "")
+		assert.True(t, c.ValueIs("k", ""))
+		assert.False(t, c.ValueIs("k", "anything"))
+	})
+
+	t.Run("key absent returns false", func(t *testing.T) {
+		c := NewCollection()
+		assert.False(t, c.ValueIs("missing", ""))
+		assert.False(t, c.ValueIs("missing", "val"))
+	})
+
+	t.Run("chainable error returns false", func(t *testing.T) {
+		c := NewCollection().Add("k", "v").WithChainableErr(errors.New("err"))
+		assert.False(t, c.ValueIs("k", "v"))
+	})
 }

--- a/port/collection.go
+++ b/port/collection.go
@@ -117,7 +117,7 @@ func (c *Collection) PutSignals(signals ...*signal.Signal) *Collection {
 //
 //	// Add labels to all input ports
 //	this.Inputs().ForEach(func(p *port.Port) {
-//	    p.AddLabel("processed", "true")
+//	    p.WithLabel("processed", "true")
 //	})
 func (c *Collection) ForEach(action func(*Port) error) *Collection {
 	if c.HasChainableErr() {
@@ -219,7 +219,7 @@ func (c *Collection) Signals() *signal.Group {
 			// Return a group with error, but don't poison the collection
 			return signal.NewGroup().WithChainableErr(err)
 		}
-		group = group.Add(signals...)
+		group = group.With(signals...)
 	}
 	return group
 }

--- a/port/port.go
+++ b/port/port.go
@@ -8,8 +8,7 @@ import (
 	"github.com/hovsep/fmesh/signal"
 )
 
-// Direction represents the direction of a port (input or output).
-// It's a boolean type where true = input, false = output.
+// Direction represents the direction of a port.
 type Direction bool
 
 const (
@@ -91,7 +90,7 @@ func (p *Port) Labels() *labels.Collection {
 	return p.labels
 }
 
-// SetLabels replaces all labels and returns the port for chaining.
+// SetLabels replaces all labels.
 func (p *Port) SetLabels(labelMap labels.Map) *Port {
 	if p.HasChainableErr() {
 		return p
@@ -100,7 +99,7 @@ func (p *Port) SetLabels(labelMap labels.Map) *Port {
 	return p
 }
 
-// AddLabels adds or updates labels and returns the port for chaining.
+// AddLabels adds or updates labels.
 func (p *Port) AddLabels(labelMap labels.Map) *Port {
 	if p.HasChainableErr() {
 		return p
@@ -109,7 +108,7 @@ func (p *Port) AddLabels(labelMap labels.Map) *Port {
 	return p
 }
 
-// AddLabel adds or updates a single label and returns the port for chaining.
+// AddLabel adds or updates a single label.
 func (p *Port) AddLabel(name, value string) *Port {
 	if p.HasChainableErr() {
 		return p
@@ -118,7 +117,7 @@ func (p *Port) AddLabel(name, value string) *Port {
 	return p
 }
 
-// ClearLabels removes all labels and returns the port for chaining.
+// ClearLabels removes all labels.
 func (p *Port) ClearLabels() *Port {
 	if p.HasChainableErr() {
 		return p
@@ -127,16 +126,16 @@ func (p *Port) ClearLabels() *Port {
 	return p
 }
 
-// WithoutLabels removes specific labels and returns the port for chaining.
-func (p *Port) WithoutLabels(names ...string) *Port {
+// RemoveLabels removes specific labels.
+func (p *Port) RemoveLabels(names ...string) *Port {
 	if p.HasChainableErr() {
 		return p
 	}
-	p.labels.Without(names...)
+	p.labels.Remove(names...)
 	return p
 }
 
-// WithDescription sets the port description and returns the port for chaining.
+// WithDescription sets the port description.
 func (p *Port) WithDescription(description string) *Port {
 	if p.HasChainableErr() {
 		return p
@@ -180,13 +179,13 @@ func (p *Port) Signals() *signal.Group {
 	return p.signals
 }
 
-// PutSignals adds signals to the port and returns the port for chaining.
+// PutSignals adds signals to the port.
 func (p *Port) PutSignals(signals ...*signal.Signal) *Port {
 	if p.HasChainableErr() {
 		return p
 	}
 
-	result := p.withSignals(p.Signals().Add(signals...))
+	result := p.withSignals(p.Signals().With(signals...))
 
 	// Trigger OnSignalsAdded hook
 	if err := p.hooks.onSignalsAdded.Trigger(&SignalsAddedContext{
@@ -199,7 +198,7 @@ func (p *Port) PutSignals(signals ...*signal.Signal) *Port {
 	return result
 }
 
-// PutPayloads creates signals from given payloads and returns the port for chaining.
+// PutPayloads creates signals from given payloads.
 func (p *Port) PutPayloads(payloads ...any) *Port {
 	if p.HasChainableErr() {
 		return p
@@ -207,7 +206,7 @@ func (p *Port) PutPayloads(payloads ...any) *Port {
 
 	newSignals, _ := signal.NewGroup(payloads...).All()
 
-	result := p.withSignals(p.Signals().Add(newSignals...))
+	result := p.withSignals(p.Signals().With(newSignals...))
 
 	// Trigger OnSignalsAdded hook
 	if err := p.hooks.onSignalsAdded.Trigger(&SignalsAddedContext{
@@ -220,7 +219,7 @@ func (p *Port) PutPayloads(payloads ...any) *Port {
 	return result
 }
 
-// PutSignalGroups adds all signals from signal groups and returns the port for chaining.
+// PutSignalGroups adds all signals from signal groups.
 func (p *Port) PutSignalGroups(signalGroups ...*signal.Group) *Port {
 	if p.HasChainableErr() {
 		return p
@@ -239,7 +238,7 @@ func (p *Port) PutSignalGroups(signalGroups ...*signal.Group) *Port {
 	return p
 }
 
-// Clear removes all signals and returns the port for chaining.
+// Clear removes all signals.
 func (p *Port) Clear() *Port {
 	if p.HasChainableErr() {
 		return p
@@ -302,7 +301,7 @@ func (p *Port) HasPipes() bool {
 	return !p.Pipes().IsEmpty()
 }
 
-// PipeTo connects this port to destination ports and returns the port for chaining.
+// PipeTo connects this port to destination ports.
 func (p *Port) PipeTo(destPorts ...*Port) *Port {
 	if p.HasChainableErr() {
 		return p
@@ -442,7 +441,7 @@ func (p *Port) WithParentComponent(parentComponent ParentComponent) *Port {
 	return p
 }
 
-// SetupHooks configures port hooks using a closure and returns the port for chaining.
+// SetupHooks configures port hooks using a closure.
 func (p *Port) SetupHooks(configure func(*Hooks)) *Port {
 	if p.HasChainableErr() {
 		return p

--- a/port/port_test.go
+++ b/port/port_test.go
@@ -729,7 +729,7 @@ func TestPort_ClearLabels(t *testing.T) {
 	}
 }
 
-func TestPort_WithoutLabels(t *testing.T) {
+func TestPort_RemoveLabels(t *testing.T) {
 	tests := []struct {
 		name           string
 		port           *Port
@@ -772,7 +772,7 @@ func TestPort_WithoutLabels(t *testing.T) {
 			port:           NewOutput("p1").AddLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}),
 			labelsToRemove: []string{"k1"},
 			assertions: func(t *testing.T, port *Port) {
-				result := port.WithoutLabels("k2").AddLabel("k4", "v4")
+				result := port.RemoveLabels("k2").AddLabel("k4", "v4")
 				assert.Equal(t, 2, result.Labels().Len())
 				assert.False(t, result.Labels().Has("k1"))
 				assert.False(t, result.Labels().Has("k2"))
@@ -783,7 +783,7 @@ func TestPort_WithoutLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			portAfter := tt.port.WithoutLabels(tt.labelsToRemove...)
+			portAfter := tt.port.RemoveLabels(tt.labelsToRemove...)
 			if tt.assertions != nil {
 				tt.assertions(t, portAfter)
 			}
@@ -1039,7 +1039,7 @@ func TestPort_ForwardWithMap(t *testing.T) {
 				srcPort:  NewOutput("p1").PutSignalGroups(signal.NewGroup(1, 2, 3)),
 				destPort: NewOutput("p2"),
 				mapperFunc: func(signal *signal.Signal) *signal.Signal {
-					return signal.SetLabels(labels.Map{
+					return signal.WithOnlyLabels(labels.Map{
 						"l1": "v1",
 					})
 				},
@@ -1048,9 +1048,7 @@ func TestPort_ForwardWithMap(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, 3, destPortAfter.Signals().Len())
 				assert.Equal(t, 3, srcPortAfter.Signals().Len())
-				assert.True(t, destPortAfter.Signals().AllMatch(func(signal *signal.Signal) bool {
-					return signal.Labels().ValueIs("l1", "v1")
-				}))
+				assert.True(t, destPortAfter.Signals().Every(signal.LabelEquals("l1", "v1")))
 			},
 		},
 		{
@@ -1164,10 +1162,10 @@ func TestPort_Chainability(t *testing.T) {
 		assert.True(t, p.Labels().ValueIs("k3", "v3"))
 	})
 
-	t.Run("WithoutLabels removes specific labels", func(t *testing.T) {
+	t.Run("RemoveLabels removes specific labels", func(t *testing.T) {
 		p := NewOutput("p1").
 			AddLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}).
-			WithoutLabels("k1", "k2").
+			RemoveLabels("k1", "k2").
 			AddLabel("k4", "v4")
 
 		assert.Equal(t, 2, p.Labels().Len())

--- a/signal/group.go
+++ b/signal/group.go
@@ -1,8 +1,11 @@
 package signal
 
-import "slices"
+import (
+	"reflect"
+	"slices"
+)
 
-// Group represents a list of signals.
+// Group represents an ordered list of signals.
 type Group struct {
 	chainableErr error
 	signals      Signals
@@ -15,7 +18,7 @@ func newGroupFromSignals(signals Signals) *Group {
 	}
 }
 
-// NewGroup creates an empty group.
+// NewGroup creates a new group from the given payloads.
 func NewGroup(payloads ...any) *Group {
 	signals := make(Signals, len(payloads))
 	for i, payload := range payloads {
@@ -24,7 +27,7 @@ func NewGroup(payloads ...any) *Group {
 	return newGroupFromSignals(signals)
 }
 
-// First returns the first signal in the group.
+// First returns the first signal in the group, or nil if empty or errored.
 func (g *Group) First() *Signal {
 	if g.HasChainableErr() {
 		return nil
@@ -33,6 +36,17 @@ func (g *Group) First() *Signal {
 		return nil
 	}
 	return g.signals[0]
+}
+
+// Last returns the last signal in the group, or nil if empty or errored.
+func (g *Group) Last() *Signal {
+	if g.HasChainableErr() {
+		return nil
+	}
+	if g.IsEmpty() {
+		return nil
+	}
+	return g.signals[len(g.signals)-1]
 }
 
 // IsEmpty returns true when there are no signals in the group.
@@ -53,17 +67,18 @@ func (g *Group) Find(predicate Predicate) *Signal {
 	return nil
 }
 
-// AnyMatch returns true if at least one signal matches the predicate.
-func (g *Group) AnyMatch(p Predicate) bool {
+// Any returns true if at least one signal matches the predicate.
+func (g *Group) Any(p Predicate) bool {
 	if g.HasChainableErr() || g.IsEmpty() {
 		return false
 	}
 	return slices.ContainsFunc(g.signals, p)
 }
 
-// AllMatch returns true if all signals match the predicate.
-func (g *Group) AllMatch(p Predicate) bool {
-	if g.HasChainableErr() || g.IsEmpty() {
+// Every returns true if all signals match the predicate.
+// Returns true for an empty group (vacuous truth).
+func (g *Group) Every(p Predicate) bool {
+	if g.HasChainableErr() {
 		return false
 	}
 	for _, sig := range g.signals {
@@ -72,6 +87,56 @@ func (g *Group) AllMatch(p Predicate) bool {
 		}
 	}
 	return true
+}
+
+// Count returns the number of signals that match the predicate.
+func (g *Group) Count(predicate Predicate) int {
+	if g.HasChainableErr() {
+		return 0
+	}
+	n := 0
+	for _, sig := range g.signals {
+		if predicate(sig) {
+			n++
+		}
+	}
+	return n
+}
+
+// Contains returns true if the group contains the exact signal (pointer identity).
+func (g *Group) Contains(s *Signal) bool {
+	if g.HasChainableErr() || g.IsEmpty() {
+		return false
+	}
+	return slices.Contains(g.signals, s)
+}
+
+// ContainsPayload returns true if any signal's payload equals the given value.
+// Panics if the payload type is not comparable; use ContainsPayloadFunc instead.
+func (g *Group) ContainsPayload(payload any) bool {
+	if payload != nil && !reflect.TypeOf(payload).Comparable() {
+		panic("ContainsPayload: payload type is not comparable, use ContainsPayloadFunc instead")
+	}
+	return g.ContainsPayloadFunc(func(p any) bool {
+		return p == payload
+	})
+}
+
+// ContainsPayloadFunc returns true if any signal's payload satisfies eq.
+func (g *Group) ContainsPayloadFunc(eq func(payload any) bool) bool {
+	if g.HasChainableErr() || g.IsEmpty() {
+		return false
+	}
+	for _, sig := range g.signals {
+		p, err := sig.Payload()
+		if err != nil {
+			continue
+		}
+		if eq(p) {
+			return true
+		}
+	}
+	return false
 }
 
 // FirstPayload returns the payload of the first signal with error handling.
@@ -116,8 +181,8 @@ func (g *Group) AllPayloads() ([]any, error) {
 	return all, nil
 }
 
-// Add returns a new group with added signals. The receiver is never modified.
-func (g *Group) Add(signals ...*Signal) *Group {
+// With returns a new group with the given signals appended. The receiver is never modified.
+func (g *Group) With(signals ...*Signal) *Group {
 	if g.HasChainableErr() {
 		return g
 	}
@@ -135,18 +200,8 @@ func (g *Group) Add(signals ...*Signal) *Group {
 	return newGroupFromSignals(newSignals)
 }
 
-// Without removes signals matching the predicate and returns a new group.
-func (g *Group) Without(predicate Predicate) *Group {
-	if g.HasChainableErr() {
-		return NewGroup().WithChainableErr(g.ChainableErr())
-	}
-	return g.Filter(func(s *Signal) bool {
-		return !predicate(s)
-	})
-}
-
-// AddFromPayloads returns a new group with added signals created from provided payloads.
-func (g *Group) AddFromPayloads(payloads ...any) *Group {
+// WithPayloads returns a new group with signals created from the given payloads appended.
+func (g *Group) WithPayloads(payloads ...any) *Group {
 	if g.HasChainableErr() {
 		return g
 	}
@@ -158,7 +213,23 @@ func (g *Group) AddFromPayloads(payloads ...any) *Group {
 	return newGroupFromSignals(newSignals)
 }
 
-// All returns a copy of all signals in the group.
+// Join returns a new group containing signals from both groups.
+func (g *Group) Join(other *Group) *Group {
+	if g.HasChainableErr() {
+		return g
+	}
+	if other.HasChainableErr() {
+		return NewGroup().WithChainableErr(other.ChainableErr())
+	}
+	newSignals := make(Signals, g.Len()+other.Len())
+	copy(newSignals, g.signals)
+	copy(newSignals[g.Len():], other.signals)
+	return newGroupFromSignals(newSignals)
+}
+
+// All returns a cloned slice of signals. The slice is independent of the group;
+// the *Signal pointers inside are shared, but Signal is copy-on-write so callers
+// cannot corrupt group state through the returned pointers.
 func (g *Group) All() (Signals, error) {
 	if g.HasChainableErr() {
 		return nil, g.ChainableErr()
@@ -221,12 +292,12 @@ func (g *Group) ForEachIf(predicate Predicate, action func(*Signal) error) *Grou
 	return g
 }
 
-// Filter returns a new group with signals that pass the filter.
+// Filter returns a new group with signals that pass the predicate.
 func (g *Group) Filter(p Predicate) *Group {
 	if g.HasChainableErr() {
 		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
-	filtered := make(Signals, 0)
+	filtered := make(Signals, 0, len(g.signals))
 	for _, s := range g.signals {
 		if p(s) {
 			filtered = append(filtered, s)
@@ -235,35 +306,48 @@ func (g *Group) Filter(p Predicate) *Group {
 	return newGroupFromSignals(filtered)
 }
 
-// Map returns a new group with signals transformed by the mapper function.
+// Map returns a new group with every signal transformed by the mapper.
 func (g *Group) Map(m Mapper) *Group {
 	if g.HasChainableErr() {
 		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
 	mapped := make(Signals, 0, len(g.signals))
 	for _, s := range g.signals {
-		mapped = append(mapped, s.Map(m))
+		mapped = append(mapped, m(cloneSignal(s)))
 	}
 	return newGroupFromSignals(mapped)
 }
 
-// MapIf is like Map but only applies the mapper function to signals that match the predicate.
+// MapIf is like Map but applies the mapper only to signals matching the predicate.
 func (g *Group) MapIf(predicate Predicate, mapper Mapper) *Group {
 	if g.HasChainableErr() {
 		return NewGroup().WithChainableErr(g.ChainableErr())
 	}
 	mapped := make(Signals, len(g.signals))
 	for i, s := range g.signals {
+		clonedSignal := cloneSignal(s)
 		if predicate(s) {
-			mapped[i] = s.Map(mapper)
+			mapped[i] = mapper(clonedSignal)
 		} else {
-			mapped[i] = cloneSignal(s)
+			mapped[i] = clonedSignal
 		}
 	}
 	return newGroupFromSignals(mapped)
 }
 
-// MapPayloadsIf is like MapPayloads but only applies the mapper to signals that match the predicate.
+// MapPayloads returns a new group with every payload transformed by the mapper.
+func (g *Group) MapPayloads(mapper PayloadMapper) *Group {
+	if g.HasChainableErr() {
+		return NewGroup().WithChainableErr(g.ChainableErr())
+	}
+	mapped := make(Signals, 0, len(g.signals))
+	for _, s := range g.signals {
+		mapped = append(mapped, s.MapPayload(mapper))
+	}
+	return newGroupFromSignals(mapped)
+}
+
+// MapPayloadsIf is like MapPayloads but applies the mapper only to signals matching the predicate.
 func (g *Group) MapPayloadsIf(predicate Predicate, mapper PayloadMapper) *Group {
 	if g.HasChainableErr() {
 		return NewGroup().WithChainableErr(g.ChainableErr())
@@ -279,28 +363,30 @@ func (g *Group) MapPayloadsIf(predicate Predicate, mapper PayloadMapper) *Group 
 	return newGroupFromSignals(mapped)
 }
 
-// MapPayloads returns a new group with payloads transformed by the mapper function.
-func (g *Group) MapPayloads(mapper PayloadMapper) *Group {
+// Reduce accumulates all signals into a single signal using the given function.
+func (g *Group) Reduce(initial *Signal, fn Reducer) *Signal {
 	if g.HasChainableErr() {
-		return NewGroup().WithChainableErr(g.ChainableErr())
+		return initial
 	}
-	mapped := make(Signals, 0, len(g.signals))
+	acc := initial
 	for _, s := range g.signals {
-		mapped = append(mapped, s.MapPayload(mapper))
+		acc = fn(acc, s)
 	}
-	return newGroupFromSignals(mapped)
+	return acc
 }
 
-// CountMatch returns the number of signals that match the predicate.
-func (g *Group) CountMatch(predicate Predicate) int {
+// ReducePayloads accumulates all signal payloads into a single value using the given function.
+func (g *Group) ReducePayloads(initial any, fn PayloadReducer) any {
 	if g.HasChainableErr() {
-		return 0
+		return initial
 	}
-	n := 0
-	for _, sig := range g.signals {
-		if predicate(sig) {
-			n++
+	acc := initial
+	for _, s := range g.signals {
+		p, err := s.Payload()
+		if err != nil {
+			continue
 		}
+		acc = fn(acc, p)
 	}
-	return n
+	return acc
 }

--- a/signal/group_test.go
+++ b/signal/group_test.go
@@ -195,9 +195,9 @@ func TestGroup_With(t *testing.T) {
 		{
 			name: "with error in chain",
 			group: NewGroup(1, 2, 3).
-				Add(New("valid before invalid")).
-				Add(nil).
-				AddFromPayloads(4, 5, 6),
+				With(New("valid before invalid")).
+				With(nil).
+				WithPayloads(4, 5, 6),
 			args: args{
 				signals: NewGroup(7, nil, 9).mustAll(),
 			},
@@ -205,18 +205,18 @@ func TestGroup_With(t *testing.T) {
 		},
 		{
 			name:  "with error in signal",
-			group: NewGroup(1, 2, 3).Add(New(44).WithChainableErr(errors.New("some error in signal"))),
+			group: NewGroup(1, 2, 3).With(New(44).WithChainableErr(errors.New("some error in signal"))),
 			args: args{
 				signals: Signals{New(456)},
 			},
 			want: NewGroup(1, 2, 3).
-				Add(New(44).WithChainableErr(errors.New("some error in signal"))).
-				WithChainableErr(errors.New("some error in signal")), // error propagated from signal to group
+				With(New(44).WithChainableErr(errors.New("some error in signal"))).
+				WithChainableErr(errors.New("some error in signal")),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.group.Add(tt.args.signals...)
+			got := tt.group.With(tt.args.signals...)
 			if tt.want.HasChainableErr() {
 				assert.Error(t, got.ChainableErr())
 				assert.EqualError(t, got.ChainableErr(), tt.want.ChainableErr().Error())
@@ -273,7 +273,7 @@ func TestGroup_WithPayloads(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.group.AddFromPayloads(tt.args.payloads...))
+			assert.Equal(t, tt.want, tt.group.WithPayloads(tt.args.payloads...))
 		})
 	}
 }
@@ -301,6 +301,151 @@ func TestGroup_First(t *testing.T) {
 	})
 }
 
+func TestGroup_Last(t *testing.T) {
+	t.Run("empty group returns nil", func(t *testing.T) {
+		assert.Nil(t, NewGroup().Last())
+	})
+
+	t.Run("single element", func(t *testing.T) {
+		group := NewGroup(42)
+		got := group.Last()
+		require.NotNil(t, got)
+		payload, err := got.Payload()
+		require.NoError(t, err)
+		assert.Equal(t, 42, payload)
+	})
+
+	t.Run("returns last element", func(t *testing.T) {
+		group := NewGroup(1, 2, 3)
+		got := group.Last()
+		require.NotNil(t, got)
+		payload, err := got.Payload()
+		require.NoError(t, err)
+		assert.Equal(t, 3, payload)
+	})
+
+	t.Run("with error in chain returns nil", func(t *testing.T) {
+		group := NewGroup(1, 2, 3).WithChainableErr(errors.New("some error"))
+		assert.Nil(t, group.Last())
+	})
+}
+
+func TestGroup_Join(t *testing.T) {
+	t.Run("join two non-empty groups", func(t *testing.T) {
+		a := NewGroup(1, 2)
+		b := NewGroup(3, 4)
+		got := a.Join(b)
+		assert.Equal(t, 4, got.Len())
+		assert.Equal(t, NewGroup(1, 2, 3, 4), got)
+	})
+
+	t.Run("join with empty group", func(t *testing.T) {
+		a := NewGroup(1, 2)
+		got := a.Join(NewGroup())
+		assert.Equal(t, NewGroup(1, 2), got)
+	})
+
+	t.Run("join empty with non-empty", func(t *testing.T) {
+		got := NewGroup().Join(NewGroup(5, 6))
+		assert.Equal(t, NewGroup(5, 6), got)
+	})
+
+	t.Run("receiver unchanged after join", func(t *testing.T) {
+		a := NewGroup(1, 2)
+		_ = a.Join(NewGroup(3, 4))
+		assert.Equal(t, 2, a.Len())
+	})
+
+	t.Run("receiver error propagates", func(t *testing.T) {
+		a := NewGroup(1).WithChainableErr(errors.New("bad"))
+		got := a.Join(NewGroup(2))
+		assert.True(t, got.HasChainableErr())
+	})
+
+	t.Run("other error propagates", func(t *testing.T) {
+		got := NewGroup(1).Join(NewGroup(2).WithChainableErr(errors.New("bad other")))
+		assert.True(t, got.HasChainableErr())
+	})
+}
+
+func TestGroup_Contains(t *testing.T) {
+	t.Run("found by pointer identity", func(t *testing.T) {
+		s := New(42)
+		g := NewGroup().With(s)
+		assert.True(t, g.Contains(s))
+	})
+
+	t.Run("not found — different pointer same value", func(t *testing.T) {
+		g := NewGroup(42)
+		assert.False(t, g.Contains(New(42)))
+	})
+
+	t.Run("empty group", func(t *testing.T) {
+		assert.False(t, NewGroup().Contains(New(1)))
+	})
+
+	t.Run("group with error", func(t *testing.T) {
+		s := New(1)
+		g := NewGroup().With(s).WithChainableErr(errors.New("e"))
+		assert.False(t, g.Contains(s))
+	})
+}
+
+func TestGroup_ContainsPayload(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		g := NewGroup(1, 2, 3)
+		assert.True(t, g.ContainsPayload(2))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		g := NewGroup(1, 2, 3)
+		assert.False(t, g.ContainsPayload(99))
+	})
+
+	t.Run("nil payload found", func(t *testing.T) {
+		g := NewGroup(nil, 1)
+		assert.True(t, g.ContainsPayload(nil))
+	})
+
+	t.Run("empty group", func(t *testing.T) {
+		assert.False(t, NewGroup().ContainsPayload(1))
+	})
+
+	t.Run("group with error", func(t *testing.T) {
+		g := NewGroup(1).WithChainableErr(errors.New("e"))
+		assert.False(t, g.ContainsPayload(1))
+	})
+
+	t.Run("non-comparable payload panics", func(t *testing.T) {
+		assert.Panics(t, func() {
+			NewGroup(1).ContainsPayload([]int{1, 2})
+		})
+	})
+}
+
+func TestGroup_ContainsPayloadFunc(t *testing.T) {
+	t.Run("found with custom comparator", func(t *testing.T) {
+		g := NewGroup([]int{1, 2}, []int{3, 4})
+		found := g.ContainsPayloadFunc(func(p any) bool {
+			s, ok := p.([]int)
+			return ok && len(s) == 2 && s[0] == 3
+		})
+		assert.True(t, found)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		g := NewGroup(1, 2, 3)
+		assert.False(t, g.ContainsPayloadFunc(func(p any) bool {
+			v, ok := p.(int)
+			return ok && v > 100
+		}))
+	})
+
+	t.Run("empty group", func(t *testing.T) {
+		assert.False(t, NewGroup().ContainsPayloadFunc(func(any) bool { return true }))
+	})
+}
+
 func TestGroup_Find(t *testing.T) {
 	t.Run("returns first matching signal", func(t *testing.T) {
 		group := NewGroup(1, 2, 3, 4)
@@ -311,7 +456,7 @@ func TestGroup_Find(t *testing.T) {
 		require.NotNil(t, got)
 		payload, err := got.Payload()
 		require.NoError(t, err)
-		assert.Equal(t, 2, payload) // first even, not all evens
+		assert.Equal(t, 2, payload)
 	})
 
 	t.Run("returns nil when no signal matches", func(t *testing.T) {
@@ -336,7 +481,7 @@ func TestGroup_Find(t *testing.T) {
 	})
 }
 
-func TestGroup_Signals(t *testing.T) {
+func TestGroup_All(t *testing.T) {
 	tests := []struct {
 		name            string
 		group           *Group
@@ -364,18 +509,13 @@ func TestGroup_Signals(t *testing.T) {
 		{
 			name: "with labeled signals",
 			group: NewGroup(1, nil, 3).Map(func(s *Signal) *Signal {
-				return s.SetLabels(labels.Map{"flavor": "banana"})
+				return s.WithOnlyLabels(labels.Map{"flavor": "banana"})
 			}),
 			want: Signals{
-				New(1).SetLabels(labels.Map{
-					"flavor": "banana",
-				}),
-				New(nil).SetLabels(labels.Map{
-					"flavor": "banana",
-				}),
-				New(3).SetLabels(labels.Map{
-					"flavor": "banana",
-				})},
+				New(1).WithOnlyLabels(labels.Map{"flavor": "banana"}),
+				New(nil).WithOnlyLabels(labels.Map{"flavor": "banana"}),
+				New(3).WithOnlyLabels(labels.Map{"flavor": "banana"}),
+			},
 			wantErrorString: "",
 		},
 	}
@@ -387,61 +527,6 @@ func TestGroup_Signals(t *testing.T) {
 				require.EqualError(t, err, tt.wantErrorString)
 			} else {
 				assert.Equal(t, tt.want, got)
-			}
-		})
-	}
-}
-
-func TestGroup_SignalsOrDefault(t *testing.T) {
-	type args struct {
-		defaultSignals Signals
-	}
-	tests := []struct {
-		name  string
-		group *Group
-		args  args
-		want  Signals
-	}{
-		{
-			name:  "empty group",
-			group: NewGroup(),
-			args: args{
-				defaultSignals: nil,
-			},
-			want: Signals{}, // Empty group has empty slice of signals
-		},
-		{
-			name:  "with signals",
-			group: NewGroup(1, 2, 3),
-			args: args{
-				defaultSignals: Signals{New(4), New(5)}, // Default must be ignored
-			},
-			want: Signals{New(1), New(2), New(3)},
-		},
-		{
-			name:  "with error in chain and nil default",
-			group: NewGroup(1, 2, 3).WithChainableErr(errors.New("some error in chain")),
-			args: args{
-				defaultSignals: nil,
-			},
-			want: nil,
-		},
-		{
-			name:  "with error in chain and default",
-			group: NewGroup(1, 2, 3).WithChainableErr(errors.New("some error in chain")),
-			args: args{
-				defaultSignals: Signals{New(4), New(5)},
-			},
-			want: Signals{New(4), New(5)},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := tt.group.All()
-			if err != nil {
-				assert.Equal(t, tt.want, tt.args.defaultSignals)
-			} else {
-				assert.Equal(t, tt.want, result)
 			}
 		})
 	}
@@ -500,14 +585,7 @@ func TestGroup_Filter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.group.Filter(tt.args.predicate)
-			if tt.want.HasChainableErr() {
-				assert.Error(t, got.ChainableErr())
-				assert.EqualError(t, got.ChainableErr(), tt.want.ChainableErr().Error())
-			} else {
-				assert.NoError(t, got.ChainableErr())
-			}
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, tt.group.Filter(tt.args.predicate))
 		})
 	}
 }
@@ -546,7 +624,7 @@ func TestGroup_Map(t *testing.T) {
 		},
 		{
 			name:  "signal with error",
-			group: NewGroup(1, 2, 3).Add(New(4).WithChainableErr(errors.New("some error in chain"))),
+			group: NewGroup(1, 2, 3).With(New(4).WithChainableErr(errors.New("some error in chain"))),
 			args: args{
 				mapperFunc: func(signal *Signal) *Signal {
 					return signal.MapPayload(func(payload any) any {
@@ -757,7 +835,7 @@ func TestGroup_MapPayloads(t *testing.T) {
 		},
 		{
 			name:  "signal with error",
-			group: NewGroup(1, 2, 3).Add(New(4).WithChainableErr(errors.New("some error in chain"))),
+			group: NewGroup(1, 2, 3).With(New(4).WithChainableErr(errors.New("some error in chain"))),
 			args: args{
 				mapperFunc: func(payload any) any {
 					return payload.(int) * 7
@@ -780,29 +858,10 @@ func TestGroup_MapPayloads(t *testing.T) {
 	}
 }
 
-func TestGroup_Without(t *testing.T) {
-	t.Run("removes matching signals", func(t *testing.T) {
-		group := NewGroup(1, 2, 3, 4, 5)
-		result := group.Without(func(s *Signal) bool {
-			payload, _ := s.Payload()
-			return payload.(int)%2 == 0 // remove even numbers
-		})
-		assert.Equal(t, 3, result.Len()) // 1, 3, 5 remain
-	})
-
-	t.Run("returns same group when has error", func(t *testing.T) {
-		group := NewGroup(1, 2, 3).WithChainableErr(assert.AnError)
-		result := group.Without(func(s *Signal) bool {
-			return true
-		})
-		assert.True(t, result.HasChainableErr())
-	})
-}
-
-func TestGroup_AllMatch(t *testing.T) {
+func TestGroup_Every(t *testing.T) {
 	t.Run("returns true when all match", func(t *testing.T) {
 		group := NewGroup(2, 4, 6)
-		result := group.AllMatch(func(s *Signal) bool {
+		result := group.Every(func(s *Signal) bool {
 			payload, _ := s.Payload()
 			return payload.(int)%2 == 0
 		})
@@ -811,34 +870,34 @@ func TestGroup_AllMatch(t *testing.T) {
 
 	t.Run("returns false when not all match", func(t *testing.T) {
 		group := NewGroup(2, 3, 4)
-		result := group.AllMatch(func(s *Signal) bool {
+		result := group.Every(func(s *Signal) bool {
 			payload, _ := s.Payload()
 			return payload.(int)%2 == 0
 		})
 		assert.False(t, result)
 	})
 
-	t.Run("returns false for empty group", func(t *testing.T) {
+	t.Run("returns true for empty group (vacuous truth)", func(t *testing.T) {
 		group := NewGroup()
-		result := group.AllMatch(func(s *Signal) bool {
+		result := group.Every(func(s *Signal) bool {
 			return true
 		})
-		assert.False(t, result)
+		assert.True(t, result)
 	})
 
 	t.Run("returns false when group has error", func(t *testing.T) {
 		group := NewGroup(1, 2).WithChainableErr(assert.AnError)
-		result := group.AllMatch(func(s *Signal) bool {
+		result := group.Every(func(s *Signal) bool {
 			return true
 		})
 		assert.False(t, result)
 	})
 }
 
-func TestGroup_AnyMatch(t *testing.T) {
+func TestGroup_Any(t *testing.T) {
 	t.Run("returns true when at least one matches", func(t *testing.T) {
 		group := NewGroup(1, 2, 3)
-		result := group.AnyMatch(func(s *Signal) bool {
+		result := group.Any(func(s *Signal) bool {
 			payload, _ := s.Payload()
 			return payload.(int) == 2
 		})
@@ -847,7 +906,7 @@ func TestGroup_AnyMatch(t *testing.T) {
 
 	t.Run("returns false when none match", func(t *testing.T) {
 		group := NewGroup(1, 3, 5)
-		result := group.AnyMatch(func(s *Signal) bool {
+		result := group.Any(func(s *Signal) bool {
 			payload, _ := s.Payload()
 			return payload.(int)%2 == 0
 		})
@@ -856,7 +915,7 @@ func TestGroup_AnyMatch(t *testing.T) {
 
 	t.Run("returns false for empty group", func(t *testing.T) {
 		group := NewGroup()
-		result := group.AnyMatch(func(s *Signal) bool {
+		result := group.Any(func(s *Signal) bool {
 			return true
 		})
 		assert.False(t, result)
@@ -864,26 +923,26 @@ func TestGroup_AnyMatch(t *testing.T) {
 
 	t.Run("returns false when group has error", func(t *testing.T) {
 		group := NewGroup(1, 2).WithChainableErr(assert.AnError)
-		result := group.AnyMatch(func(s *Signal) bool {
+		result := group.Any(func(s *Signal) bool {
 			return true
 		})
 		assert.False(t, result)
 	})
 }
 
-func TestGroup_CountMatch(t *testing.T) {
+func TestGroup_Count(t *testing.T) {
 	t.Run("counts matching signals", func(t *testing.T) {
 		group := NewGroup(1, 2, 3, 4, 5)
-		count := group.CountMatch(func(s *Signal) bool {
+		count := group.Count(func(s *Signal) bool {
 			payload, _ := s.Payload()
 			return payload.(int)%2 == 0
 		})
-		assert.Equal(t, 2, count) // 2 and 4
+		assert.Equal(t, 2, count)
 	})
 
 	t.Run("returns 0 for empty group", func(t *testing.T) {
 		group := NewGroup()
-		count := group.CountMatch(func(s *Signal) bool {
+		count := group.Count(func(s *Signal) bool {
 			return true
 		})
 		assert.Equal(t, 0, count)
@@ -891,7 +950,7 @@ func TestGroup_CountMatch(t *testing.T) {
 
 	t.Run("returns 0 when group has error", func(t *testing.T) {
 		group := NewGroup(1, 2, 3).WithChainableErr(assert.AnError)
-		count := group.CountMatch(func(s *Signal) bool {
+		count := group.Count(func(s *Signal) bool {
 			return true
 		})
 		assert.Equal(t, 0, count)
@@ -942,7 +1001,7 @@ func TestGroup_ForEachIf(t *testing.T) {
 				return nil
 			},
 		)
-		assert.Equal(t, 2, count) // 2 and 4
+		assert.Equal(t, 2, count)
 	})
 
 	t.Run("applies action to all when predicate always true", func(t *testing.T) {
@@ -997,29 +1056,137 @@ func TestGroup_Len(t *testing.T) {
 	})
 }
 
-func TestGroup_FirstDoesNotPoisonGroup(t *testing.T) {
-	t.Run("First does not poison group when empty", func(t *testing.T) {
-		group := NewGroup()
-
-		// Query first on empty group
-		result := group.First()
-
-		// Result should be nil
-		assert.Nil(t, result)
-
-		// Group should NOT be poisoned
-		assert.False(t, group.HasChainableErr())
-
-		// Group should still be usable for adding
-		group = group.Add(New(42))
-		assert.Equal(t, 1, group.Len())
-		assert.False(t, group.HasChainableErr())
-
-		// Now First should work
-		first := group.First()
-		require.NotNil(t, first)
-		payload, err := first.Payload()
+func TestGroup_Reduce(t *testing.T) {
+	t.Run("accumulates signals", func(t *testing.T) {
+		g := NewGroup(1, 2, 3)
+		result := g.Reduce(New(0), func(acc, s *Signal) *Signal {
+			accVal, _ := acc.Payload()
+			sVal, _ := s.Payload()
+			return New(accVal.(int) + sVal.(int))
+		})
+		require.NotNil(t, result)
+		payload, err := result.Payload()
 		require.NoError(t, err)
-		assert.Equal(t, 42, payload)
+		assert.Equal(t, 6, payload)
+	})
+
+	t.Run("returns initial for empty group", func(t *testing.T) {
+		initial := New(99)
+		result := NewGroup().Reduce(initial, func(acc, s *Signal) *Signal { return s })
+		assert.Equal(t, initial, result)
+	})
+
+	t.Run("returns initial when group has error", func(t *testing.T) {
+		initial := New(0)
+		result := NewGroup(1, 2).WithChainableErr(assert.AnError).Reduce(initial, func(acc, s *Signal) *Signal {
+			return s
+		})
+		assert.Equal(t, initial, result)
+	})
+}
+
+func TestGroup_ReducePayloads(t *testing.T) {
+	t.Run("sums integers", func(t *testing.T) {
+		g := NewGroup(1, 2, 3, 4)
+		result := g.ReducePayloads(0, func(acc, payload any) any {
+			return acc.(int) + payload.(int)
+		})
+		assert.Equal(t, 10, result)
+	})
+
+	t.Run("concatenates strings", func(t *testing.T) {
+		g := NewGroup("a", "b", "c")
+		result := g.ReducePayloads("", func(acc, payload any) any {
+			return acc.(string) + payload.(string)
+		})
+		assert.Equal(t, "abc", result)
+	})
+
+	t.Run("returns initial for empty group", func(t *testing.T) {
+		result := NewGroup().ReducePayloads(42, func(acc, payload any) any { return payload })
+		assert.Equal(t, 42, result)
+	})
+
+	t.Run("returns initial when group has error", func(t *testing.T) {
+		result := NewGroup(1, 2).WithChainableErr(assert.AnError).ReducePayloads(0, func(acc, payload any) any {
+			return acc.(int) + payload.(int)
+		})
+		assert.Equal(t, 0, result)
+	})
+}
+
+func TestGroup_FirstDoesNotPoisonGroup(t *testing.T) {
+	group := NewGroup()
+
+	result := group.First()
+	assert.Nil(t, result)
+	assert.False(t, group.HasChainableErr())
+
+	group = group.With(New(42))
+	assert.Equal(t, 1, group.Len())
+	assert.False(t, group.HasChainableErr())
+
+	first := group.First()
+	require.NotNil(t, first)
+	payload, err := first.Payload()
+	require.NoError(t, err)
+	assert.Equal(t, 42, payload)
+}
+
+// TestGroup_NilPayloadInvariant verifies that nil is a valid payload in a group
+// and survives group operations unchanged.
+func TestGroup_NilPayloadInvariant(t *testing.T) {
+	t.Run("First returns nil-payload signal", func(t *testing.T) {
+		got, err := NewGroup(nil, 1).First().Payload()
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("Last returns nil-payload signal", func(t *testing.T) {
+		got, err := NewGroup(1, nil).Last().Payload()
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("Filter preserves nil-payload signals", func(t *testing.T) {
+		filtered := NewGroup(nil, 1, nil).Filter(func(s *Signal) bool {
+			return s.PayloadOrDefault("x") == nil
+		})
+		assert.Equal(t, 2, filtered.Len())
+		got, err := filtered.First().Payload()
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("Map preserves nil-payload signals", func(t *testing.T) {
+		got, err := NewGroup(nil).Map(func(s *Signal) *Signal {
+			return s.WithLabel("touched", "yes")
+		}).First().Payload()
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("Join preserves nil-payload signals", func(t *testing.T) {
+		joined := NewGroup(nil).Join(NewGroup(nil))
+		assert.Equal(t, 2, joined.Len())
+
+		first, err := joined.First().Payload()
+		require.NoError(t, err)
+		assert.Nil(t, first)
+
+		last, err := joined.Last().Payload()
+		require.NoError(t, err)
+		assert.Nil(t, last)
+	})
+
+	t.Run("AllPayloads includes nil entries", func(t *testing.T) {
+		payloads, err := NewGroup(1, nil, 2).AllPayloads()
+		require.NoError(t, err)
+		assert.Equal(t, []any{1, nil, 2}, payloads)
+	})
+
+	t.Run("ContainsPayload finds nil", func(t *testing.T) {
+		assert.True(t, NewGroup(nil, 1).ContainsPayload(nil))
+		assert.False(t, NewGroup(1, 2).ContainsPayload(nil))
 	})
 }

--- a/signal/immutability_test.go
+++ b/signal/immutability_test.go
@@ -14,11 +14,11 @@ import (
 
 func TestSignal_immutable_builder_operations(t *testing.T) {
 	t.Run("AddLabel_leaves_receiver_unchanged", func(t *testing.T) {
-		orig := New(42).AddLabel("a", "1")
+		orig := New(42).WithLabel("a", "1")
 		require.Equal(t, 1, orig.Labels().Len())
 		require.True(t, orig.Labels().ValueIs("a", "1"))
 
-		next := orig.AddLabel("b", "2")
+		next := orig.WithLabel("b", "2")
 		require.NotNil(t, next)
 
 		assert.Equal(t, 1, orig.Labels().Len(), "receiver must keep prior labels only")
@@ -30,8 +30,8 @@ func TestSignal_immutable_builder_operations(t *testing.T) {
 	})
 
 	t.Run("AddLabels_leaves_receiver_unchanged", func(t *testing.T) {
-		orig := New(1).AddLabel("k", "v")
-		next := orig.AddLabels(labels.Map{"x": "y"})
+		orig := New(1).WithLabel("k", "v")
+		next := orig.WithLabels(labels.Map{"x": "y"})
 
 		assert.Equal(t, 1, orig.Labels().Len())
 		assert.True(t, orig.Labels().ValueIs("k", "v"))
@@ -42,8 +42,8 @@ func TestSignal_immutable_builder_operations(t *testing.T) {
 	})
 
 	t.Run("SetLabels_leaves_receiver_unchanged", func(t *testing.T) {
-		orig := New(1).AddLabel("keep", "old")
-		next := orig.SetLabels(labels.Map{"new": "set"})
+		orig := New(1).WithLabel("keep", "old")
+		next := orig.WithOnlyLabels(labels.Map{"new": "set"})
 
 		assert.True(t, orig.Labels().ValueIs("keep", "old"))
 		assert.False(t, orig.Labels().Has("new"))
@@ -53,8 +53,8 @@ func TestSignal_immutable_builder_operations(t *testing.T) {
 	})
 
 	t.Run("ClearLabels_leaves_receiver_unchanged", func(t *testing.T) {
-		orig := New(1).AddLabel("a", "1")
-		next := orig.ClearLabels()
+		orig := New(1).WithLabel("a", "1")
+		next := orig.WithNoLabels()
 
 		assert.Equal(t, 1, orig.Labels().Len())
 		assert.True(t, orig.Labels().Has("a"))
@@ -63,7 +63,7 @@ func TestSignal_immutable_builder_operations(t *testing.T) {
 	})
 
 	t.Run("WithoutLabels_leaves_receiver_unchanged", func(t *testing.T) {
-		orig := New(1).AddLabels(labels.Map{"a": "1", "b": "2"})
+		orig := New(1).WithLabels(labels.Map{"a": "1", "b": "2"})
 		next := orig.WithoutLabels("b")
 
 		assert.Equal(t, 2, orig.Labels().Len())
@@ -74,7 +74,7 @@ func TestSignal_immutable_builder_operations(t *testing.T) {
 	})
 
 	t.Run("WithChainableErr_leaves_receiver_unchanged", func(t *testing.T) {
-		orig := New(7).AddLabel("k", "v")
+		orig := New(7).WithLabel("k", "v")
 		sentinel := errors.New("sentinel")
 		next := orig.WithChainableErr(sentinel)
 
@@ -88,7 +88,7 @@ func TestSignal_immutable_builder_operations(t *testing.T) {
 }
 
 func TestSignal_MapPayload_leaves_receiver_unchanged(t *testing.T) {
-	orig := New(10).AddLabel("trace", "id")
+	orig := New(10).WithLabel("trace", "id")
 	next := orig.MapPayload(func(p any) any { return p.(int) * 2 })
 
 	p0, err := orig.Payload()
@@ -106,12 +106,12 @@ func TestSignal_MapPayload_leaves_receiver_unchanged(t *testing.T) {
 func TestGroup_Add_does_not_poison_receiver_on_invalid_signal(t *testing.T) {
 	t.Run("nil_signal", func(t *testing.T) {
 		g := NewGroup(1)
-		_ = g.Add(nil)
+		_ = g.With(nil)
 
 		assert.False(t, g.HasChainableErr(), "receiver must not retain Add error")
 		assert.Equal(t, 1, g.Len())
 
-		g2 := g.Add(New(99))
+		g2 := g.With(New(99))
 		assert.False(t, g2.HasChainableErr())
 		assert.Equal(t, 2, g2.Len())
 	})
@@ -119,12 +119,12 @@ func TestGroup_Add_does_not_poison_receiver_on_invalid_signal(t *testing.T) {
 	t.Run("signal_with_chainable_error", func(t *testing.T) {
 		g := NewGroup(1)
 		bad := New(2).WithChainableErr(errors.New("bad signal"))
-		_ = g.Add(bad)
+		_ = g.With(bad)
 
 		assert.False(t, g.HasChainableErr())
 		assert.Equal(t, 1, g.Len())
 
-		g2 := g.Add(New(3))
+		g2 := g.With(New(3))
 		assert.False(t, g2.HasChainableErr())
 		assert.Equal(t, 2, g2.Len())
 	})
@@ -163,10 +163,26 @@ func TestGroup_MapIf_non_matching_signals_are_not_shared_pointers(t *testing.T) 
 	require.NotEqual(t, uintptr(unsafe.Pointer(g.First())), uintptr(unsafe.Pointer(outSigs[0])),
 		"MapIf pass-through must use cloned signals, not shared pointers (#203)")
 
-	_ = outSigs[0].AddLabel("x", "y")
+	_ = outSigs[0].WithLabel("x", "y")
 
 	assert.False(t, g.First().Labels().Has("x"),
 		"mutating output group's signal must not change original group's signal (#203)")
+}
+
+func TestGroup_Map_identity_mapper_does_not_alias(t *testing.T) {
+	g := NewGroup(1, 2)
+	identity := func(s *Signal) *Signal { return s }
+	out := g.Map(identity)
+
+	outSigs, err := out.All()
+	require.NoError(t, err)
+	require.Len(t, outSigs, 2)
+	require.NotEqual(t, uintptr(unsafe.Pointer(g.First())), uintptr(unsafe.Pointer(outSigs[0])),
+		"Map with identity mapper must clone signals, not share pointers")
+
+	_ = outSigs[0].WithLabel("x", "y")
+	assert.False(t, g.First().Labels().Has("x"),
+		"mutating output group's signal must not change original group's signal")
 }
 
 func TestGroup_MapPayloadsIf_non_matching_signals_are_not_shared_pointers(t *testing.T) {
@@ -184,7 +200,7 @@ func TestGroup_MapPayloadsIf_non_matching_signals_are_not_shared_pointers(t *tes
 	require.Len(t, outSigs, 2)
 	require.NotEqual(t, uintptr(unsafe.Pointer(g.First())), uintptr(unsafe.Pointer(outSigs[0])))
 
-	_ = outSigs[0].AddLabel("x", "y")
+	_ = outSigs[0].WithLabel("x", "y")
 
 	assert.False(t, g.First().Labels().Has("x"),
 		"mutating output group's signal must not change original group's signal (#203)")

--- a/signal/predicates.go
+++ b/signal/predicates.go
@@ -1,0 +1,64 @@
+package signal
+
+import "strings"
+
+// Not returns a predicate that is the logical negation of p.
+func Not(p Predicate) Predicate {
+	return func(s *Signal) bool {
+		return !p(s)
+	}
+}
+
+// And returns a predicate that is true only when both p1 and p2 are true.
+func And(p1, p2 Predicate) Predicate {
+	return func(s *Signal) bool {
+		return p1(s) && p2(s)
+	}
+}
+
+// Or returns a predicate that is true when at least one of p1 or p2 is true.
+func Or(p1, p2 Predicate) Predicate {
+	return func(s *Signal) bool {
+		return p1(s) || p2(s)
+	}
+}
+
+// HasLabel returns a predicate that is true when the signal has a label with the given name.
+func HasLabel(name string) Predicate {
+	return func(s *Signal) bool {
+		return s.Labels().Has(name)
+	}
+}
+
+// LabelEquals returns a predicate that is true when the signal has a label with the given name and exact value.
+func LabelEquals(name, value string) Predicate {
+	return func(s *Signal) bool {
+		return s.Labels().ValueIs(name, value)
+	}
+}
+
+// LabelContains returns a predicate that is true when the signal has a label with the given name
+// and the label's value contains the given substring.
+func LabelContains(name, substr string) Predicate {
+	return func(s *Signal) bool {
+		v, err := s.Labels().Value(name)
+		if err != nil {
+			return false
+		}
+		return strings.Contains(v, substr)
+	}
+}
+
+// HasAllLabels returns a predicate that is true when the signal has all of the given label names.
+func HasAllLabels(names ...string) Predicate {
+	return func(s *Signal) bool {
+		return s.Labels().HasAll(names...)
+	}
+}
+
+// HasAnyLabel returns a predicate that is true when the signal has at least one of the given label names.
+func HasAnyLabel(names ...string) Predicate {
+	return func(s *Signal) bool {
+		return s.Labels().HasAny(names...)
+	}
+}

--- a/signal/predicates_test.go
+++ b/signal/predicates_test.go
@@ -1,0 +1,119 @@
+package signal
+
+import (
+	"testing"
+
+	"github.com/hovsep/fmesh/labels"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNot(t *testing.T) {
+	alwaysTrue := func(s *Signal) bool { return true }
+	alwaysFalse := func(s *Signal) bool { return false }
+
+	assert.False(t, Not(alwaysTrue)(New(1)))
+	assert.True(t, Not(alwaysFalse)(New(1)))
+}
+
+func TestAnd(t *testing.T) {
+	isPositive := func(s *Signal) bool {
+		v, _ := s.Payload()
+		return v.(int) > 0
+	}
+	isEven := func(s *Signal) bool {
+		v, _ := s.Payload()
+		return v.(int)%2 == 0
+	}
+
+	assert.True(t, And(isPositive, isEven)(New(4)))
+	assert.False(t, And(isPositive, isEven)(New(3)))
+	assert.False(t, And(isPositive, isEven)(New(-2)))
+}
+
+func TestOr(t *testing.T) {
+	isZero := func(s *Signal) bool {
+		v, _ := s.Payload()
+		return v.(int) == 0
+	}
+	isNeg := func(s *Signal) bool {
+		v, _ := s.Payload()
+		return v.(int) < 0
+	}
+
+	assert.True(t, Or(isZero, isNeg)(New(0)))
+	assert.True(t, Or(isZero, isNeg)(New(-5)))
+	assert.False(t, Or(isZero, isNeg)(New(1)))
+}
+
+func TestHasLabel(t *testing.T) {
+	s := New(1).WithLabel("env", "prod")
+
+	assert.True(t, HasLabel("env")(s))
+	assert.False(t, HasLabel("region")(s))
+}
+
+func TestLabelEquals(t *testing.T) {
+	s := New(1).WithLabel("env", "prod")
+
+	assert.True(t, LabelEquals("env", "prod")(s))
+	assert.False(t, LabelEquals("env", "staging")(s))
+	assert.False(t, LabelEquals("region", "us")(s))
+}
+
+func TestLabelContains(t *testing.T) {
+	s := New(1).WithLabel("tag", "urgent-request")
+
+	assert.True(t, LabelContains("tag", "urgent")(s))
+	assert.True(t, LabelContains("tag", "request")(s))
+	assert.False(t, LabelContains("tag", "critical")(s))
+	assert.False(t, LabelContains("missing", "x")(s))
+}
+
+func TestHasAllLabels(t *testing.T) {
+	s := New(1).WithLabels(labels.Map{"a": "1", "b": "2", "c": "3"})
+
+	assert.True(t, HasAllLabels("a", "b")(s))
+	assert.True(t, HasAllLabels("a", "b", "c")(s))
+	assert.False(t, HasAllLabels("a", "d")(s))
+	assert.True(t, HasAllLabels()(s)) // vacuous
+}
+
+func TestHasAnyLabel(t *testing.T) {
+	s := New(1).WithLabels(labels.Map{"a": "1", "b": "2"})
+
+	assert.True(t, HasAnyLabel("a", "z")(s))
+	assert.True(t, HasAnyLabel("b")(s))
+	assert.False(t, HasAnyLabel("x", "y")(s))
+}
+
+func TestPredicateCombinators_composition(t *testing.T) {
+	g := NewGroup(1, 2, 3, 4, 5, 6).Map(func(s *Signal) *Signal {
+		v, _ := s.Payload()
+		if v.(int)%2 == 0 {
+			return s.WithLabel("even", "true")
+		}
+		return s.WithLabel("odd", "true")
+	})
+
+	// Keep only even signals using combinator
+	evens := g.Filter(HasLabel("even"))
+	assert.Equal(t, 3, evens.Len())
+
+	// Keep odd signals via Not
+	odds := g.Filter(Not(HasLabel("even")))
+	assert.Equal(t, 3, odds.Len())
+
+	// And: even AND payload > 3  → 4, 6
+	bigEvens := g.Filter(And(HasLabel("even"), func(s *Signal) bool {
+		v, _ := s.Payload()
+		return v.(int) > 3
+	}))
+	assert.Equal(t, 2, bigEvens.Len())
+
+	// Or: has "odd" label OR payload == 6  → 1,3,5,6
+	oddOrSix := g.Filter(Or(HasLabel("odd"), func(s *Signal) bool {
+		v, _ := s.Payload()
+		return v.(int) == 6
+	}))
+	assert.Equal(t, 4, oddOrSix.Len())
+}

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -26,7 +26,8 @@ func cloneLabels(c *labels.Collection) *labels.Collection {
 	return c.Filter(func(string, string) bool { return true })
 }
 
-// cloneSignal returns a deep copy suitable for aliasing-free group operations.
+// cloneSignal returns a copy of s with an independent labels collection.
+// Payload is shallow-copied.
 func cloneSignal(s *Signal) *Signal {
 	if s == nil {
 		return nil
@@ -55,42 +56,42 @@ func (s *Signal) Labels() *labels.Collection {
 	return cloneLabels(s.labels)
 }
 
-// SetLabels replaces all labels and returns a new signal.
-func (s *Signal) SetLabels(labelMap labels.Map) *Signal {
+// WithOnlyLabels replaces all labels and returns a new signal.
+func (s *Signal) WithOnlyLabels(labelMap labels.Map) *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	next := s.cloneForMutation()
+	next := cloneSignal(s)
 	next.labels = labels.NewCollection().AddMany(maps.Clone(labelMap))
 	return next
 }
 
-// AddLabels adds or updates labels and returns a new signal.
-func (s *Signal) AddLabels(labelMap labels.Map) *Signal {
+// WithLabels adds or updates labels and returns a new signal.
+func (s *Signal) WithLabels(labelMap labels.Map) *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	next := s.cloneForMutation()
+	next := cloneSignal(s)
 	next.labels = next.labels.AddMany(maps.Clone(labelMap))
 	return next
 }
 
-// AddLabel adds or updates a single label and returns a new signal.
-func (s *Signal) AddLabel(name, value string) *Signal {
+// WithLabel adds or updates a single label and returns a new signal.
+func (s *Signal) WithLabel(name, value string) *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	next := s.cloneForMutation()
+	next := cloneSignal(s)
 	next.labels = next.labels.Add(name, value)
 	return next
 }
 
-// ClearLabels removes all labels and returns a new signal.
-func (s *Signal) ClearLabels() *Signal {
+// WithNoLabels removes all labels and returns a new signal.
+func (s *Signal) WithNoLabels() *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	next := s.cloneForMutation()
+	next := cloneSignal(s)
 	next.labels = labels.NewCollection()
 	return next
 }
@@ -100,20 +101,30 @@ func (s *Signal) WithoutLabels(names ...string) *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	next := s.cloneForMutation()
-	next.labels = next.labels.Without(names...)
+	next := cloneSignal(s)
+	next.labels = next.labels.Remove(names...)
 	return next
 }
 
-func (s *Signal) cloneForMutation() *Signal {
-	return &Signal{
-		chainableErr: s.chainableErr,
-		labels:       cloneLabels(s.labels),
-		payload:      slices.Clone(s.payload),
+// MapPayload applies a mapper function to the signal's payload and returns a new signal.
+// The new signal preserves all labels from the original signal.
+func (s *Signal) MapPayload(mapper PayloadMapper) *Signal {
+	if s.HasChainableErr() {
+		return s
 	}
+
+	payload, err := s.Payload()
+	if err != nil {
+		return New(nil).WithChainableErr(err)
+	}
+
+	out := New(mapper(payload))
+	out.labels = cloneLabels(s.labels)
+	return out
 }
 
-// Payload returns the signal's payload.
+// Payload returns the signal's payload. The value is shallow: if the payload is
+// a pointer, slice, or map, the caller must not mutate it.
 func (s *Signal) Payload() (any, error) {
 	if s.HasChainableErr() {
 		return nil, s.ChainableErr()
@@ -159,22 +170,5 @@ func (s *Signal) Map(m Mapper) *Signal {
 	if s.HasChainableErr() {
 		return s
 	}
-	return m(s)
-}
-
-// MapPayload applies a mapper function to the signal's payload and returns a new signal.
-// The new signal preserves all labels from the original signal.
-func (s *Signal) MapPayload(mapper PayloadMapper) *Signal {
-	if s.HasChainableErr() {
-		return s
-	}
-
-	payload, err := s.Payload()
-	if err != nil {
-		return New(nil).WithChainableErr(err)
-	}
-
-	out := New(mapper(payload))
-	out.labels = cloneLabels(s.labels)
-	return out
+	return m(cloneSignal(s))
 }

--- a/signal/signal_test.go
+++ b/signal/signal_test.go
@@ -120,11 +120,11 @@ func TestSignal_Map(t *testing.T) {
 			name:   "happy path",
 			signal: New(1),
 			mapperFunc: func(signal *Signal) *Signal {
-				return signal.SetLabels(labels.Map{
+				return signal.WithOnlyLabels(labels.Map{
 					"l1": "v1",
 				})
 			},
-			want: New(1).SetLabels(labels.Map{
+			want: New(1).WithOnlyLabels(labels.Map{
 				"l1": "v1",
 			}),
 		},
@@ -132,7 +132,7 @@ func TestSignal_Map(t *testing.T) {
 			name:   "with chain error",
 			signal: New(1).WithChainableErr(errors.New("some error in chain")),
 			mapperFunc: func(signal *Signal) *Signal {
-				return signal.SetLabels(labels.Map{
+				return signal.WithOnlyLabels(labels.Map{
 					"l1": "v1",
 				})
 			},
@@ -141,7 +141,7 @@ func TestSignal_Map(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.mapperFunc(tt.signal))
+			assert.Equal(t, tt.want, tt.signal.Map(tt.mapperFunc))
 		})
 	}
 }
@@ -155,11 +155,11 @@ func TestSignal_MapPayload(t *testing.T) {
 	}{
 		{
 			name:   "happy path",
-			signal: New(1).AddLabel("foo", "bar"),
+			signal: New(1).WithLabel("foo", "bar"),
 			mapperFunc: func(payload any) any {
 				return payload.(int) * 2
 			},
-			want: New(2).AddLabel("foo", "bar"),
+			want: New(2).WithLabel("foo", "bar"),
 		},
 		{
 			name:   "with chain error",
@@ -171,14 +171,14 @@ func TestSignal_MapPayload(t *testing.T) {
 		},
 		{
 			name:   "payload nil",
-			signal: New(nil).AddLabel("x", "y"),
+			signal: New(nil).WithLabel("x", "y"),
 			mapperFunc: func(payload any) any {
 				if payload == nil {
 					return "default"
 				}
 				return payload
 			},
-			want: New("default").AddLabel("x", "y"),
+			want: New("default").WithLabel("x", "y"),
 		},
 	}
 	for _, tt := range tests {
@@ -191,7 +191,7 @@ func TestSignal_MapPayload(t *testing.T) {
 	}
 }
 
-func TestSignal_SetLabels(t *testing.T) {
+func TestSignal_WithOnlyLabels(t *testing.T) {
 	tests := []struct {
 		name       string
 		signal     *Signal
@@ -212,7 +212,7 @@ func TestSignal_SetLabels(t *testing.T) {
 		},
 		{
 			name:   "set labels replaces existing labels",
-			signal: New(123).AddLabels(labels.Map{"old": "value"}),
+			signal: New(123).WithLabels(labels.Map{"old": "value"}),
 			labels: labels.Map{
 				"l1": "v1",
 				"l2": "v2",
@@ -226,7 +226,7 @@ func TestSignal_SetLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			signalAfter := tt.signal.SetLabels(tt.labels)
+			signalAfter := tt.signal.WithOnlyLabels(tt.labels)
 			if tt.assertions != nil {
 				tt.assertions(t, signalAfter)
 			}
@@ -234,7 +234,7 @@ func TestSignal_SetLabels(t *testing.T) {
 	}
 }
 
-func TestSignal_AddLabels(t *testing.T) {
+func TestSignal_WithLabels(t *testing.T) {
 	tests := []struct {
 		name       string
 		signal     *Signal
@@ -255,7 +255,7 @@ func TestSignal_AddLabels(t *testing.T) {
 		},
 		{
 			name:   "add labels merges with existing",
-			signal: New(123).AddLabels(labels.Map{"existing": "label"}),
+			signal: New(123).WithLabels(labels.Map{"existing": "label"}),
 			labels: labels.Map{
 				"l1": "v1",
 				"l2": "v2",
@@ -267,7 +267,7 @@ func TestSignal_AddLabels(t *testing.T) {
 		},
 		{
 			name:   "add labels updates existing key",
-			signal: New(123).AddLabels(labels.Map{"l1": "old"}),
+			signal: New(123).WithLabels(labels.Map{"l1": "old"}),
 			labels: labels.Map{
 				"l1": "new",
 			},
@@ -279,7 +279,7 @@ func TestSignal_AddLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			signalAfter := tt.signal.AddLabels(tt.labels)
+			signalAfter := tt.signal.WithLabels(tt.labels)
 			if tt.assertions != nil {
 				tt.assertions(t, signalAfter)
 			}
@@ -287,7 +287,7 @@ func TestSignal_AddLabels(t *testing.T) {
 	}
 }
 
-func TestSignal_AddLabel(t *testing.T) {
+func TestSignal_WithLabel(t *testing.T) {
 	tests := []struct {
 		name       string
 		signal     *Signal
@@ -307,7 +307,7 @@ func TestSignal_AddLabel(t *testing.T) {
 		},
 		{
 			name:       "add label merges with existing",
-			signal:     New(123).AddLabel("existing", "label"),
+			signal:     New(123).WithLabel("existing", "label"),
 			labelName:  "priority",
 			labelValue: "high",
 			assertions: func(t *testing.T, signal *Signal) {
@@ -317,7 +317,7 @@ func TestSignal_AddLabel(t *testing.T) {
 		},
 		{
 			name:       "add label updates existing key",
-			signal:     New(123).AddLabel("priority", "low"),
+			signal:     New(123).WithLabel("priority", "low"),
 			labelName:  "priority",
 			labelValue: "high",
 			assertions: func(t *testing.T, signal *Signal) {
@@ -331,7 +331,7 @@ func TestSignal_AddLabel(t *testing.T) {
 			labelName:  "l1",
 			labelValue: "v1",
 			assertions: func(t *testing.T, signal *Signal) {
-				result := signal.AddLabel("l2", "v2").AddLabel("l3", "v3")
+				result := signal.WithLabel("l2", "v2").WithLabel("l3", "v3")
 				assert.Equal(t, 3, result.Labels().Len())
 				assert.True(t, result.labels.HasAll("l1", "l2", "l3"))
 			},
@@ -339,7 +339,7 @@ func TestSignal_AddLabel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			signalAfter := tt.signal.AddLabel(tt.labelName, tt.labelValue)
+			signalAfter := tt.signal.WithLabel(tt.labelName, tt.labelValue)
 			if tt.assertions != nil {
 				tt.assertions(t, signalAfter)
 			}
@@ -347,7 +347,7 @@ func TestSignal_AddLabel(t *testing.T) {
 	}
 }
 
-func TestSignal_ClearLabels(t *testing.T) {
+func TestSignal_WithNoLabels(t *testing.T) {
 	tests := []struct {
 		name       string
 		signal     *Signal
@@ -355,7 +355,7 @@ func TestSignal_ClearLabels(t *testing.T) {
 	}{
 		{
 			name:   "clear labels from signal with labels",
-			signal: New(123).AddLabels(labels.Map{"k1": "v1", "k2": "v2"}),
+			signal: New(123).WithLabels(labels.Map{"k1": "v1", "k2": "v2"}),
 			assertions: func(t *testing.T, signal *Signal) {
 				assert.Equal(t, 0, signal.Labels().Len())
 				assert.False(t, signal.Labels().Has("k1"))
@@ -371,9 +371,9 @@ func TestSignal_ClearLabels(t *testing.T) {
 		},
 		{
 			name:   "chainable",
-			signal: New(123).AddLabels(labels.Map{"k1": "v1"}),
+			signal: New(123).WithLabels(labels.Map{"k1": "v1"}),
 			assertions: func(t *testing.T, signal *Signal) {
-				result := signal.ClearLabels().AddLabel("k2", "v2")
+				result := signal.WithNoLabels().WithLabel("k2", "v2")
 				assert.Equal(t, 1, result.Labels().Len())
 				assert.False(t, result.Labels().Has("k1"))
 				assert.True(t, result.Labels().ValueIs("k2", "v2"))
@@ -382,7 +382,7 @@ func TestSignal_ClearLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			signalAfter := tt.signal.ClearLabels()
+			signalAfter := tt.signal.WithNoLabels()
 			if tt.assertions != nil {
 				tt.assertions(t, signalAfter)
 			}
@@ -399,7 +399,7 @@ func TestSignal_WithoutLabels(t *testing.T) {
 	}{
 		{
 			name:           "remove single label",
-			signal:         New(123).AddLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}),
+			signal:         New(123).WithLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}),
 			labelsToRemove: []string{"k1"},
 			assertions: func(t *testing.T, signal *Signal) {
 				assert.Equal(t, 2, signal.Labels().Len())
@@ -410,7 +410,7 @@ func TestSignal_WithoutLabels(t *testing.T) {
 		},
 		{
 			name:           "remove multiple labels",
-			signal:         New(123).AddLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}),
+			signal:         New(123).WithLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}),
 			labelsToRemove: []string{"k1", "k2"},
 			assertions: func(t *testing.T, signal *Signal) {
 				assert.Equal(t, 1, signal.Labels().Len())
@@ -421,7 +421,7 @@ func TestSignal_WithoutLabels(t *testing.T) {
 		},
 		{
 			name:           "remove non-existent label",
-			signal:         New(123).AddLabels(labels.Map{"k1": "v1"}),
+			signal:         New(123).WithLabels(labels.Map{"k1": "v1"}),
 			labelsToRemove: []string{"k2"},
 			assertions: func(t *testing.T, signal *Signal) {
 				assert.Equal(t, 1, signal.Labels().Len())
@@ -430,10 +430,10 @@ func TestSignal_WithoutLabels(t *testing.T) {
 		},
 		{
 			name:           "chainable",
-			signal:         New(123).AddLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}),
+			signal:         New(123).WithLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}),
 			labelsToRemove: []string{"k1"},
 			assertions: func(t *testing.T, signal *Signal) {
-				result := signal.WithoutLabels("k2").AddLabel("k4", "v4")
+				result := signal.WithoutLabels("k2").WithLabel("k4", "v4")
 				assert.Equal(t, 2, result.Labels().Len())
 				assert.False(t, result.Labels().Has("k1"))
 				assert.False(t, result.Labels().Has("k2"))
@@ -453,10 +453,10 @@ func TestSignal_WithoutLabels(t *testing.T) {
 }
 
 func TestSignal_Chainability(t *testing.T) {
-	t.Run("SetLabels called twice replaces all labels", func(t *testing.T) {
+	t.Run("WithOnlyLabels called twice replaces all labels", func(t *testing.T) {
 		s := New(123).
-			SetLabels(labels.Map{"k1": "v1", "k2": "v2"}).
-			SetLabels(labels.Map{"k3": "v3"})
+			WithOnlyLabels(labels.Map{"k1": "v1", "k2": "v2"}).
+			WithOnlyLabels(labels.Map{"k3": "v3"})
 
 		assert.Equal(t, 1, s.Labels().Len())
 		assert.False(t, s.Labels().Has("k1"), "k1 should be replaced")
@@ -464,10 +464,10 @@ func TestSignal_Chainability(t *testing.T) {
 		assert.True(t, s.Labels().ValueIs("k3", "v3"))
 	})
 
-	t.Run("AddLabels called twice merges labels", func(t *testing.T) {
+	t.Run("WithLabels called twice merges labels", func(t *testing.T) {
 		s := New(123).
-			AddLabels(labels.Map{"k1": "v1", "k2": "v2"}).
-			AddLabels(labels.Map{"k3": "v3", "k2": "v2-updated"})
+			WithLabels(labels.Map{"k1": "v1", "k2": "v2"}).
+			WithLabels(labels.Map{"k3": "v3", "k2": "v2-updated"})
 
 		assert.Equal(t, 3, s.Labels().Len())
 		assert.True(t, s.Labels().ValueIs("k1", "v1"))
@@ -477,24 +477,24 @@ func TestSignal_Chainability(t *testing.T) {
 
 	t.Run("mixed Set and Add operations", func(t *testing.T) {
 		s := New(123).
-			AddLabel("k1", "v1").
-			AddLabels(labels.Map{"k2": "v2", "k3": "v3"}).
-			SetLabels(labels.Map{"k4": "v4"}). // Wipes k1, k2, k3
-			AddLabel("k5", "v5")               // Merges with k4
+			WithLabel("k1", "v1").
+			WithLabels(labels.Map{"k2": "v2", "k3": "v3"}).
+			WithOnlyLabels(labels.Map{"k4": "v4"}). // Wipes k1, k2, k3
+			WithLabel("k5", "v5")                   // Merges with k4
 
 		assert.Equal(t, 2, s.Labels().Len())
-		assert.False(t, s.Labels().Has("k1"), "wiped by SetLabels")
-		assert.False(t, s.Labels().Has("k2"), "wiped by SetLabels")
-		assert.False(t, s.Labels().Has("k3"), "wiped by SetLabels")
+		assert.False(t, s.Labels().Has("k1"), "wiped by WithOnlyLabels")
+		assert.False(t, s.Labels().Has("k2"), "wiped by WithOnlyLabels")
+		assert.False(t, s.Labels().Has("k3"), "wiped by WithOnlyLabels")
 		assert.True(t, s.Labels().ValueIs("k4", "v4"))
 		assert.True(t, s.Labels().ValueIs("k5", "v5"))
 	})
 
-	t.Run("ClearLabels removes all labels", func(t *testing.T) {
+	t.Run("WithNoLabels removes all labels", func(t *testing.T) {
 		s := New(123).
-			AddLabels(labels.Map{"k1": "v1", "k2": "v2"}).
-			ClearLabels().
-			AddLabel("k3", "v3")
+			WithLabels(labels.Map{"k1": "v1", "k2": "v2"}).
+			WithNoLabels().
+			WithLabel("k3", "v3")
 
 		assert.Equal(t, 1, s.Labels().Len())
 		assert.False(t, s.Labels().Has("k1"))
@@ -504,9 +504,9 @@ func TestSignal_Chainability(t *testing.T) {
 
 	t.Run("WithoutLabels removes specific labels", func(t *testing.T) {
 		s := New(123).
-			AddLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}).
+			WithLabels(labels.Map{"k1": "v1", "k2": "v2", "k3": "v3"}).
 			WithoutLabels("k1", "k2").
-			AddLabel("k4", "v4")
+			WithLabel("k4", "v4")
 
 		assert.Equal(t, 2, s.Labels().Len())
 		assert.False(t, s.Labels().Has("k1"))
@@ -514,4 +514,53 @@ func TestSignal_Chainability(t *testing.T) {
 		assert.True(t, s.Labels().ValueIs("k3", "v3"))
 		assert.True(t, s.Labels().ValueIs("k4", "v4"))
 	})
+}
+
+// TestSignal_NilPayloadInvariant verifies that nil is a valid payload and survives
+// all mutation operations (copy-on-write label changes) unchanged.
+func TestSignal_NilPayloadInvariant(t *testing.T) {
+	tests := []struct {
+		name   string
+		signal *Signal
+	}{
+		{
+			name:   "New(nil)",
+			signal: New(nil),
+		},
+		{
+			name:   "after WithLabel",
+			signal: New(nil).WithLabel("k", "v"),
+		},
+		{
+			name:   "after WithLabels",
+			signal: New(nil).WithLabels(labels.Map{"k": "v"}),
+		},
+		{
+			name:   "after WithOnlyLabels",
+			signal: New(nil).WithOnlyLabels(labels.Map{"k": "v"}),
+		},
+		{
+			name:   "after WithNoLabels",
+			signal: New(nil).WithLabel("k", "v").WithNoLabels(),
+		},
+		{
+			name:   "after WithoutLabels",
+			signal: New(nil).WithLabel("k", "v").WithoutLabels("k"),
+		},
+		{
+			name:   "after MapPayload identity",
+			signal: New(nil).MapPayload(func(p any) any { return p }),
+		},
+		{
+			name:   "after Map",
+			signal: New(nil).Map(func(s *Signal) *Signal { return s.WithLabel("x", "y") }),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := tt.signal.Payload()
+			require.NoError(t, err)
+			assert.Nil(t, payload)
+		})
+	}
 }

--- a/signal/types.go
+++ b/signal/types.go
@@ -9,5 +9,11 @@ type Mapper func(signal *Signal) *Signal
 // PayloadMapper transforms a payload into a new payload.
 type PayloadMapper func(payload any) any
 
+// Reducer accumulates signals into a single signal.
+type Reducer func(acc *Signal, s *Signal) *Signal
+
+// PayloadReducer accumulates payloads into a single value.
+type PayloadReducer func(acc any, payload any) any
+
 // Signals is a slice of signals.
 type Signals []*Signal


### PR DESCRIPTION
This pull request introduces comprehensive documentation and API consistency improvements for the `signal`, `labels`, and `component` packages, along with updates to integration tests and test helpers. The focus is on clarifying design decisions, enforcing naming conventions, improving test coverage, and ensuring a clean, predictable API for both copy-on-write and mutating operations. The most significant changes are summarized below.

---

### Documentation and Design

* Added new design, naming, testing, and workflow guides under `.agent/docs/`, detailing architecture, invariants, method naming conventions, testing style, and safe editing practices. These documents serve as reference for contributors and help ensure consistency across the codebase. [[1]](diffhunk://#diff-a8e053aa9a47e459f866eef065231a00f10e7d3a0526b0cdca5a4991e9e46854R1-R37) [[2]](diffhunk://#diff-0afa21f6e8bc4d64825ff6e43a9f5a682695e785017b7604f4b6777aaca5905fR1-R32) [[3]](diffhunk://#diff-48039c68bd599603d590b99b133a4c0bb4e9eda4bdcd86e2433485cbdb98b5ddR1-R15) [[4]](diffhunk://#diff-c0f86d6e568c30d33e5b0ea3e783c61df99927446d929ac09cea096df81858d0R1-R24)
* Updated `AGENTS.md` to reference the new documentation and clarify project structure and contribution rules.

### API Cleanup and Consistency

* Overhauled the `signal` and `labels` package APIs for consistency:
  - Renamed methods for clarity (e.g., `AnyMatch` → `Any`, `AllMatch` → `Every`, `AddFromPayloads` → `AddPayloads`).
  - Removed `Without` from `signal.Group` in favor of predicate combinators (`Filter(Not(p))`).
  - Added new combinators and predicate constructors to `signal/predicates.go` for expressive filtering.
  - Improved and clarified mutating vs. copy-on-write method prefixes in both code and documentation. [[1]](diffhunk://#diff-0afa21f6e8bc4d64825ff6e43a9f5a682695e785017b7604f4b6777aaca5905fR1-R32) [[2]](diffhunk://#diff-17057b17317d12b5ff2ea007670bb6e2e02a43fdf8b5c8ee68092a9ea9201093R1-R131)

* Updated the `component.Component` API to match naming conventions:
  - Renamed `WithoutLabels` to `RemoveLabels` and updated all usages and comments accordingly.
  - Simplified method comments to state only what the method does, not how or usage guidance. [[1]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L52-R52) [[2]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L70-R70) [[3]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L79-R79) [[4]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L88-R88) [[5]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L97-R97) [[6]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L106-R111) [[7]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L183-R183)

### Test and Integration Updates

* Updated all affected tests to use the new method names and conventions, including:
  - `component/component_test.go` (`RemoveLabels`)
  - `integration_tests/chainability/chainability_test.go` (uses `WithLabel`, `WithLabels`, `WithOnlyLabels`, and `RemoveLabels` for signals and components)
  - Added/updated tests for new API features and edge cases in `signal` and `labels`. [[1]](diffhunk://#diff-95d56827e4fc8e5b3bb6844f548320c59d6a14cc6c6eb5c6449f6b2dc25e5aadL277-R277) [[2]](diffhunk://#diff-95d56827e4fc8e5b3bb6844f548320c59d6a14cc6c6eb5c6449f6b2dc25e5aadL320-R320) [[3]](diffhunk://#diff-95d56827e4fc8e5b3bb6844f548320c59d6a14cc6c6eb5c6449f6b2dc25e5aadL331-R331) [[4]](diffhunk://#diff-95d56827e4fc8e5b3bb6844f548320c59d6a14cc6c6eb5c6449f6b2dc25e5aadL419-R422) [[5]](diffhunk://#diff-839e6fc0ee76166169a300fb2f033369af0fe4d87a5c81f9fd873bbf23013ed7L51-R57) [[6]](diffhunk://#diff-839e6fc0ee76166169a300fb2f033369af0fe4d87a5c81f9fd873bbf23013ed7L72-R72) [[7]](diffhunk://#diff-839e6fc0ee76166169a300fb2f033369af0fe4d87a5c81f9fd873bbf23013ed7L109-R118) [[8]](diffhunk://#diff-839e6fc0ee76166169a300fb2f033369af0fe4d87a5c81f9fd873bbf23013ed7L143-R143)

---

These changes improve maintainability, enforce a clear and consistent API, and provide thorough documentation for current and future contributors. [[1]](diffhunk://#diff-a8e053aa9a47e459f866eef065231a00f10e7d3a0526b0cdca5a4991e9e46854R1-R37) [[2]](diffhunk://#diff-0afa21f6e8bc4d64825ff6e43a9f5a682695e785017b7604f4b6777aaca5905fR1-R32) [[3]](diffhunk://#diff-48039c68bd599603d590b99b133a4c0bb4e9eda4bdcd86e2433485cbdb98b5ddR1-R15) [[4]](diffhunk://#diff-c0f86d6e568c30d33e5b0ea3e783c61df99927446d929ac09cea096df81858d0R1-R24) [[5]](diffhunk://#diff-17057b17317d12b5ff2ea007670bb6e2e02a43fdf8b5c8ee68092a9ea9201093R1-R131)