### PR TITLE
Polish public api

### DIFF
--- a/.agent/docs/naming.md
+++ b/.agent/docs/naming.md
@@ -19,14 +19,10 @@ Use `With` **only** when the method is one of:
 - **Builder that does real work beyond field assignment**: e.g. nil guard + prefix logic, iteration over child objects, appending to a slice
 
 Use `Set` for **everything else** that is a plain `field = value; return receiver` mutating method, whether exported or unexported:
-- Exported example: `component.SetDescription`, `cycle.SetNumber`, `component.SetActivationFunc` (method)
+- Exported example: `cycle.SetNumber`, `component.SetLogger` (method needed post-construction for mesh logger inheritance)
 - Unexported example: `port.setSignals`, `port.setPorts`
 
-**Key distinction for dual-form APIs** (method + functional option):
-```
-component.WithActivationFunc(f)  // free Option constructor — stays With
-c.SetActivationFunc(f)           // method setter on *Component — Set
-```
+**No dual-form duplication**: if a capability has a `With*` constructor option, do **not** also add a `Set*` method for the same capability. Keep one form: `With*` for options inside `New(...)`, `Set*` only when genuine post-construction mutation is needed (e.g. `SetLogger` called by `fmesh.AddComponents`).
 
 ## Label operations by type
 
@@ -64,15 +60,19 @@ For other groups/collections (mutating): `WithLabel`/`WithScalar` mutate the rec
 
 ## Constructor options
 
-`WithLabelOption(k, v)` and `WithScalarOption(k, v)` are `Option` functions available for all
+`WithLabel(k, v)` and `WithScalar(k, v)` are `Option` functions available for all
 constructors that accept options (`fmesh.New`, `component.New`, `port.NewInput`, `port.NewOutput`).
 
-Some capabilities exist in **two forms** — a functional `Option` constructor (used inside `New(...)`) and a fluent method (used after construction). The naming rule differs by form:
+Constructor options use the `With` prefix and are passed to `New(...)`:
 
-| Form | Prefix | Example |
-|---|---|---|
-| Free `Option` constructor | `With` | `component.WithActivationFunc(f)`, `port.WithDescription(s)` |
-| Fluent method on receiver | `Set` | `c.SetActivationFunc(f)`, `c.SetDescription(s)` |
+| Capability | Option |
+|---|---|
+| Activation function | `component.WithActivationFunc(f)` |
+| Component description | `component.WithDescription(s)` |
+| Initial state | `component.WithInitialState(fn)` |
+| Logger | `component.WithLogger(l)` |
+
+Post-construction `Set*` methods exist only where mutation is genuinely required after `New()` returns — currently `SetLogger` (called by `fmesh.AddComponents` to inherit the mesh logger) and `SetParentMesh`.
 
 ## Collection/group operations
 
@@ -86,7 +86,6 @@ infallible (e.g. `Filter`, `Map`, `signal.Signal` builders) keep their fluent re
 need to wrap `error` where nothing can go wrong.
 
 `ForEach` on all collection types returns `error` (stops on first).
-`signal.Group.ForEach` returns `(*Group, error)` — the processed group plus any error.
 
 ## Predicates
 

--- a/component/activation.go
+++ b/component/activation.go
@@ -15,13 +15,6 @@ func WithActivationFunc(f ActivationFunc) Option {
 	}
 }
 
-// SetActivationFunc sets the activation function on the component and returns the component for chaining.
-// This method can be called after construction; the option form is preferred when building inside New().
-func (c *Component) SetActivationFunc(f ActivationFunc) *Component {
-	c.f = f
-	return c
-}
-
 // MaybeActivate tries to run the activation function if all required conditions are met.
 func (c *Component) MaybeActivate() *ActivationResult {
 	if !c.Inputs().AnyHasSignals() {

--- a/component/activation_test.go
+++ b/component/activation_test.go
@@ -13,61 +13,33 @@ import (
 )
 
 func TestComponent_WithActivationFunc(t *testing.T) {
-	type args struct {
-		f ActivationFunc
-	}
-	tests := []struct {
-		name      string
-		component *Component
-		args      args
-	}{
-		{
-			name: "happy path",
-			component: func() *Component {
-				c, err := New("c1")
-				require.NoError(t, err)
-				require.NoError(t, c.AddOutputs("out1"))
-				return c
-			}(),
-			args: args{
-				f: func(this *Component) error {
-					if out := this.OutputByName("out1"); out != nil {
-						return out.PutSignals(signal.New(23))
-					}
-					return nil
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			componentAfter := tt.component.SetActivationFunc(tt.args.f)
+	t.Run("happy path", func(t *testing.T) {
+		f := func(this *Component) error {
+			if out := this.OutputByName("out1"); out != nil {
+				return out.PutSignals(signal.New(23))
+			}
+			return nil
+		}
+		c := mustNew("c1", WithOutputs("out1"), WithActivationFunc(f))
+		assert.NotNil(t, c.f)
 
-			// Compare activation functions by they result and error
-			dummyComponent1, err := New("c1")
-			require.NoError(t, err)
-			require.NoError(t, dummyComponent1.AddInputs("i1", "i2"))
-			require.NoError(t, dummyComponent1.AddOutputs("o1", "o2"))
+		// Verify the assigned function produces the same output as the original
+		dummy1 := mustNew("d1", WithOutputs("out1"))
+		dummy2 := mustNew("d2", WithOutputs("out1"))
+		err1 := c.f(dummy1)
+		err2 := f(dummy2)
+		assert.Equal(t, err1, err2)
+		assert.ElementsMatch(t, dummy1.OutputByName("out1").Signals().All(), dummy2.OutputByName("out1").Signals().All())
+	})
 
-			dummyComponent2, err := New("c2")
-			require.NoError(t, err)
-			require.NoError(t, dummyComponent2.AddInputs("i1", "i2"))
-			require.NoError(t, dummyComponent2.AddOutputs("o1", "o2"))
-
-			err1 := componentAfter.f(dummyComponent1)
-			err2 := tt.args.f(dummyComponent2)
-			assert.Equal(t, err1, err2)
-
-			// Compare signals without keys (because they are random)
-			o1Signals1 := dummyComponent1.OutputByName("o1").Signals().All()
-			o1Signals2 := dummyComponent2.OutputByName("o1").Signals().All()
-			assert.ElementsMatch(t, o1Signals1, o1Signals2)
-
-			o2Signals1 := dummyComponent1.OutputByName("o2").Signals().All()
-			o2Signals2 := dummyComponent2.OutputByName("o2").Signals().All()
-			assert.ElementsMatch(t, o2Signals1, o2Signals2)
-		})
-	}
+	t.Run("WithActivationFunc replaces previous value", func(t *testing.T) {
+		first := func(this *Component) error { return nil }
+		second := func(this *Component) error { return errors.New("second") }
+		c := mustNew("c1", WithActivationFunc(first), WithActivationFunc(second))
+		require.NotNil(t, c.f)
+		err := c.f(c)
+		assert.EqualError(t, err, "second")
+	})
 }
 
 func TestComponent_MaybeActivate(t *testing.T) {
@@ -80,13 +52,14 @@ func TestComponent_MaybeActivate(t *testing.T) {
 		{
 			name: "component with activation func, but no inputs",
 			getComponent: func() *Component {
-				c, err := New("c1")
+				c, err := New("c1",
+					WithInputs("i1"),
+					WithOutputs("o1"),
+					WithActivationFunc(func(this *Component) error {
+						return port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))
+					}),
+				)
 				require.NoError(t, err)
-				require.NoError(t, c.AddInputs("i1"))
-				require.NoError(t, c.AddOutputs("o1"))
-				c.SetActivationFunc(func(this *Component) error {
-					return port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))
-				})
 				return c
 			},
 			wantActivationResult: NewActivationResult("c1").
@@ -96,12 +69,13 @@ func TestComponent_MaybeActivate(t *testing.T) {
 		{
 			name: "activated with error",
 			getComponent: func() *Component {
-				c, err := New("c1")
+				c, err := New("c1",
+					WithInputs("i1"),
+					WithActivationFunc(func(this *Component) error {
+						return errors.New("test error")
+					}),
+				)
 				require.NoError(t, err)
-				require.NoError(t, c.AddInputs("i1"))
-				c.SetActivationFunc(func(this *Component) error {
-					return errors.New("test error")
-				})
 				require.NoError(t, c.InputByName("i1").PutSignals(signal.New(123)))
 				return c
 			},
@@ -113,13 +87,14 @@ func TestComponent_MaybeActivate(t *testing.T) {
 		{
 			name: "activated without error",
 			getComponent: func() *Component {
-				c, err := New("c1")
+				c, err := New("c1",
+					WithInputs("i1"),
+					WithOutputs("o1"),
+					WithActivationFunc(func(this *Component) error {
+						return port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))
+					}),
+				)
 				require.NoError(t, err)
-				require.NoError(t, c.AddInputs("i1"))
-				require.NoError(t, c.AddOutputs("o1"))
-				c.SetActivationFunc(func(this *Component) error {
-					return port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))
-				})
 				require.NoError(t, c.InputByName("i1").PutSignals(signal.New(123)))
 				return c
 			},
@@ -130,13 +105,14 @@ func TestComponent_MaybeActivate(t *testing.T) {
 		{
 			name: "component panicked with error",
 			getComponent: func() *Component {
-				c, err := New("c1")
+				c, err := New("c1",
+					WithInputs("i1"),
+					WithOutputs("o1"),
+					WithActivationFunc(func(this *Component) error {
+						panic(errors.New("oh shrimps"))
+					}),
+				)
 				require.NoError(t, err)
-				require.NoError(t, c.AddInputs("i1"))
-				require.NoError(t, c.AddOutputs("o1"))
-				c.SetActivationFunc(func(this *Component) error {
-					panic(errors.New("oh shrimps"))
-				})
 				require.NoError(t, c.InputByName("i1").PutSignals(signal.New(123)))
 				return c
 			},
@@ -148,13 +124,14 @@ func TestComponent_MaybeActivate(t *testing.T) {
 		{
 			name: "component panicked with string",
 			getComponent: func() *Component {
-				c, err := New("c1")
+				c, err := New("c1",
+					WithInputs("i1"),
+					WithOutputs("o1"),
+					WithActivationFunc(func(this *Component) error {
+						panic("oh shrimps")
+					}),
+				)
 				require.NoError(t, err)
-				require.NoError(t, c.AddInputs("i1"))
-				require.NoError(t, c.AddOutputs("o1"))
-				c.SetActivationFunc(func(this *Component) error {
-					panic("oh shrimps")
-				})
 				require.NoError(t, c.InputByName("i1").PutSignals(signal.New(123)))
 				return c
 			},
@@ -166,16 +143,17 @@ func TestComponent_MaybeActivate(t *testing.T) {
 		{
 			name: "component is waiting for inputs",
 			getComponent: func() *Component {
-				c, err := New("c1")
+				c, err := New("c1",
+					WithInputs("i1", "i2"),
+					WithOutputs("o1"),
+					WithActivationFunc(func(this *Component) error {
+						if !this.Inputs().ByNames("i1", "i2").AllHaveSignals() {
+							return ErrWaitingForInputs
+						}
+						return nil
+					}),
+				)
 				require.NoError(t, err)
-				require.NoError(t, c.AddInputs("i1", "i2"))
-				require.NoError(t, c.AddOutputs("o1"))
-				c.SetActivationFunc(func(this *Component) error {
-					if !this.Inputs().ByNames("i1", "i2").AllHaveSignals() {
-						return ErrWaitingForInputs
-					}
-					return nil
-				})
 				require.NoError(t, c.InputByName("i1").PutSignals(signal.New(123)))
 				return c
 			},
@@ -189,16 +167,17 @@ func TestComponent_MaybeActivate(t *testing.T) {
 		{
 			name: "component is waiting for inputs and wants to keep them",
 			getComponent: func() *Component {
-				c, err := New("c1")
+				c, err := New("c1",
+					WithInputs("i1", "i2"),
+					WithOutputs("o1"),
+					WithActivationFunc(func(this *Component) error {
+						if !this.Inputs().ByNames("i1", "i2").AllHaveSignals() {
+							return ErrWaitingForInputsKeep
+						}
+						return nil
+					}),
+				)
 				require.NoError(t, err)
-				require.NoError(t, c.AddInputs("i1", "i2"))
-				require.NoError(t, c.AddOutputs("o1"))
-				c.SetActivationFunc(func(this *Component) error {
-					if !this.Inputs().ByNames("i1", "i2").AllHaveSignals() {
-						return ErrWaitingForInputsKeep
-					}
-					return nil
-				})
 				require.NoError(t, c.InputByName("i1").PutSignals(signal.New(123)))
 				return c
 			},
@@ -212,14 +191,15 @@ func TestComponent_MaybeActivate(t *testing.T) {
 		{
 			name: "component not activated, logger must be empty",
 			getComponent: func() *Component {
-				c, err := New("c1")
+				c, err := New("c1",
+					WithInputs("i1"),
+					WithOutputs("o1"),
+					WithActivationFunc(func(this *Component) error {
+						this.Logger().Println("This must not be logged, as component must not activate")
+						return nil
+					}),
+				)
 				require.NoError(t, err)
-				require.NoError(t, c.AddInputs("i1"))
-				require.NoError(t, c.AddOutputs("o1"))
-				c.SetActivationFunc(func(this *Component) error {
-					this.Logger().Println("This must not be logged, as component must not activate")
-					return nil
-				})
 				return c
 			},
 			wantActivationResult: NewActivationResult("c1").
@@ -232,13 +212,14 @@ func TestComponent_MaybeActivate(t *testing.T) {
 		{
 			name: "activated with error, with logging",
 			getComponent: func() *Component {
-				c, err := New("c1")
+				c, err := New("c1",
+					WithInputs("i1"),
+					WithActivationFunc(func(this *Component) error {
+						this.logger.Println("This line must be logged")
+						return errors.New("test error")
+					}),
+				)
 				require.NoError(t, err)
-				require.NoError(t, c.AddInputs("i1"))
-				c.SetActivationFunc(func(this *Component) error {
-					this.logger.Println("This line must be logged")
-					return errors.New("test error")
-				})
 				require.NoError(t, c.InputByName("i1").PutSignals(signal.New(123)))
 				return c
 			},
@@ -258,7 +239,7 @@ func TestComponent_MaybeActivate(t *testing.T) {
 			var loggerOutput bytes.Buffer
 			logger.SetOutput(&loggerOutput)
 
-			gotActivationResult := tt.getComponent().WithLogger(logger).MaybeActivate()
+			gotActivationResult := tt.getComponent().SetLogger(logger).MaybeActivate()
 			assert.Equal(t, tt.wantActivationResult.Activated(), gotActivationResult.Activated())
 			assert.Equal(t, tt.wantActivationResult.ComponentName(), gotActivationResult.ComponentName())
 			assert.Equal(t, tt.wantActivationResult.Code(), gotActivationResult.Code())
@@ -277,10 +258,11 @@ func TestComponent_MaybeActivate(t *testing.T) {
 
 func TestComponent_MaybeActivate_HookFailures(t *testing.T) {
 	t.Run("beforeActivation hook fails: ActivationCodeHookFailed, not activated, error captured", func(t *testing.T) {
-		c, err := New("c1")
+		c, err := New("c1",
+			WithInputs("i1"),
+			WithActivationFunc(func(this *Component) error { return nil }),
+		)
 		require.NoError(t, err)
-		require.NoError(t, c.AddInputs("i1"))
-		c.SetActivationFunc(func(this *Component) error { return nil })
 		c.SetupHooks(func(h *Hooks) {
 			h.BeforeActivation(func(_ *Component) error {
 				return errors.New("before hook error")
@@ -298,10 +280,11 @@ func TestComponent_MaybeActivate_HookFailures(t *testing.T) {
 	})
 
 	t.Run("onSuccess hook fails: ActivationCodeHookFailed, error accumulated", func(t *testing.T) {
-		c, err := New("c1")
+		c, err := New("c1",
+			WithInputs("i1"),
+			WithActivationFunc(func(this *Component) error { return nil }),
+		)
 		require.NoError(t, err)
-		require.NoError(t, c.AddInputs("i1"))
-		c.SetActivationFunc(func(this *Component) error { return nil })
 		c.SetupHooks(func(h *Hooks) {
 			h.OnSuccess(func(_ *ActivationContext) error {
 				return errors.New("onSuccess hook error")
@@ -318,12 +301,13 @@ func TestComponent_MaybeActivate_HookFailures(t *testing.T) {
 	})
 
 	t.Run("onError hook fails: ActivationCodeHookFailed, both errors accumulated", func(t *testing.T) {
-		c, err := New("c1")
+		c, err := New("c1",
+			WithInputs("i1"),
+			WithActivationFunc(func(this *Component) error {
+				return errors.New("component error")
+			}),
+		)
 		require.NoError(t, err)
-		require.NoError(t, c.AddInputs("i1"))
-		c.SetActivationFunc(func(this *Component) error {
-			return errors.New("component error")
-		})
 		c.SetupHooks(func(h *Hooks) {
 			h.OnError(func(_ *ActivationContext) error {
 				return errors.New("onError hook error")
@@ -340,10 +324,11 @@ func TestComponent_MaybeActivate_HookFailures(t *testing.T) {
 	})
 
 	t.Run("afterActivation hook fails: ActivationCodeHookFailed, error accumulated", func(t *testing.T) {
-		c, err := New("c1")
+		c, err := New("c1",
+			WithInputs("i1"),
+			WithActivationFunc(func(this *Component) error { return nil }),
+		)
 		require.NoError(t, err)
-		require.NoError(t, c.AddInputs("i1"))
-		c.SetActivationFunc(func(this *Component) error { return nil })
 		c.SetupHooks(func(h *Hooks) {
 			h.AfterActivation(func(_ *ActivationContext) error {
 				return errors.New("afterActivation hook error")

--- a/component/component.go
+++ b/component/component.go
@@ -54,12 +54,6 @@ func (c *Component) Description() string {
 	return c.description
 }
 
-// SetDescription sets the component description.
-func (c *Component) SetDescription(description string) *Component {
-	c.description = description
-	return c
-}
-
 // Labels returns the component's labels collection.
 func (c *Component) Labels() *meta.Labels {
 	return c.labels
@@ -130,31 +124,52 @@ func (c *Component) RemoveScalars(names ...string) *Component {
 	return c
 }
 
-// WithLabelOption is a component constructor option that adds or updates a single label.
-func WithLabelOption(name, value string) Option {
+// WithDescription is a component constructor option that sets the description.
+func WithDescription(description string) Option {
+	return func(c *Component) error {
+		c.description = description
+		return nil
+	}
+}
+
+// WithLabel is a component constructor option that adds or updates a single label.
+func WithLabel(name, value string) Option {
 	return func(c *Component) error {
 		c.labels.Set(name, value)
 		return nil
 	}
 }
 
-// WithScalarOption is a component constructor option that adds or updates a single scalar.
-func WithScalarOption(name string, value float64) Option {
+// WithScalar is a component constructor option that adds or updates a single scalar.
+func WithScalar(name string, value float64) Option {
 	return func(c *Component) error {
 		c.scalars.Set(name, value)
 		return nil
 	}
 }
 
-// WithLogger creates a new logger prefixed with component name.
-func (c *Component) WithLogger(logger *log.Logger) *Component {
+// WithLogger is a component constructor option that creates a new logger prefixed with component name.
+func WithLogger(logger *log.Logger) Option {
+	return func(c *Component) error {
+		c.setLogger(logger)
+		return nil
+	}
+}
+
+// SetLogger creates a new logger prefixed with component name and sets it on the component.
+func (c *Component) SetLogger(logger *log.Logger) *Component {
+	c.setLogger(logger)
+	return c
+}
+
+// setLogger is the shared implementation for logger setup with nil-guard and prefix logic.
+func (c *Component) setLogger(logger *log.Logger) {
 	if logger == nil {
-		return c
+		return
 	}
 
 	prefix := fmt.Sprintf("%s: %s ", c.Name(), logger.Prefix())
 	c.logger = log.New(logger.Writer(), prefix, logger.Flags())
-	return c
 }
 
 // Logger returns the component's logger.

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -3,8 +3,6 @@ package component
 import (
 	"testing"
 
-	"github.com/hovsep/fmesh/meta"
-	"github.com/hovsep/fmesh/port"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,39 +36,20 @@ func TestNewComponent(t *testing.T) {
 }
 
 func TestComponent_WithDescription(t *testing.T) {
-	type args struct {
-		description string
-	}
-	tests := []struct {
-		name      string
-		component *Component
-		args      args
-		want      *Component
-	}{
-		{
-			name:      "happy path",
-			component: mustNew("c1"),
-			args: args{
-				description: "descr",
-			},
-			want: &Component{
-				name:        "c1",
-				description: "descr",
-				labels:      meta.NewLabels(),
-				scalars:     meta.NewScalars(),
-				inputPorts:  port.NewCollection(),
-				outputPorts: port.NewCollection(),
-				f:           nil,
-				state:       NewState(),
-				hooks:       NewHooks(),
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.component.SetDescription(tt.args.description))
-		})
-	}
+	t.Run("sets description via option", func(t *testing.T) {
+		c := mustNew("c1", WithDescription("descr"))
+		assert.Equal(t, "descr", c.Description())
+	})
+
+	t.Run("empty by default", func(t *testing.T) {
+		c := mustNew("c1")
+		assert.Empty(t, c.Description())
+	})
+
+	t.Run("WithDescription replaces previous value", func(t *testing.T) {
+		c := mustNew("c1", WithDescription("first"), WithDescription("second"))
+		assert.Equal(t, "second", c.Description())
+	})
 }
 
 func TestComponent_SetLabels(t *testing.T) {
@@ -373,10 +352,7 @@ func TestComponent_Chainability(t *testing.T) {
 	})
 
 	t.Run("WithDescription replaces previous value", func(t *testing.T) {
-		c := mustNew("c1").
-			SetDescription("first").
-			SetDescription("second")
-
+		c := mustNew("c1", WithDescription("first"), WithDescription("second"))
 		assert.Equal(t, "second", c.Description())
 	})
 

--- a/component/io_test.go
+++ b/component/io_test.go
@@ -20,12 +20,8 @@ func TestComponent_AddInputs(t *testing.T) {
 		assertions func(t *testing.T, component *Component)
 	}{
 		{
-			name: "happy path",
-			component: func() *Component {
-				c := mustNew("c1")
-				c.SetActivationFunc(func(this *Component) error { return nil })
-				return c
-			}(),
+			name:      "happy path",
+			component: mustNew("c1", WithActivationFunc(func(this *Component) error { return nil })),
 			args: args{
 				portNames: []string{"p1", "p2"},
 			},
@@ -74,12 +70,8 @@ func TestComponent_AddOutputs(t *testing.T) {
 		assertions func(t *testing.T, component *Component)
 	}{
 		{
-			name: "happy path",
-			component: func() *Component {
-				c := mustNew("c1")
-				c.SetActivationFunc(func(this *Component) error { return nil })
-				return c
-			}(),
+			name:      "happy path",
+			component: mustNew("c1", WithActivationFunc(func(this *Component) error { return nil })),
 			args: args{
 				portNames: []string{"p1", "p2"},
 			},

--- a/component/state.go
+++ b/component/state.go
@@ -12,13 +12,14 @@ func NewState() State {
 	return make(State)
 }
 
-// WithInitialState initializes the component state and returns the component for chaining.
-func (c *Component) WithInitialState(init func(state State)) *Component {
-	if init != nil {
-		init(c.state)
+// WithInitialState is a component constructor option that initializes the component state.
+func WithInitialState(init func(state State)) Option {
+	return func(c *Component) error {
+		if init != nil {
+			init(c.state)
+		}
+		return nil
 	}
-
-	return c
 }
 
 // State returns the component's state.

--- a/component/state_test.go
+++ b/component/state_test.go
@@ -19,12 +19,12 @@ func TestComponent_WithInitialState(t *testing.T) {
 		},
 		{
 			name: "with initial state",
-			component: mustNew("c1").WithInitialState(func(state State) {
+			component: mustNew("c1", WithInitialState(func(state State) {
 				state.Set("battery", 100.00)
 				state.Set("speed", 200)
 				state.Set("data", []byte{1, 2, 3})
 				state.Set("secret", "LEON")
-			}),
+			})),
 			wantState: State{
 				"battery": 100.00,
 				"speed":   200,
@@ -34,7 +34,7 @@ func TestComponent_WithInitialState(t *testing.T) {
 		},
 		{
 			name:      "with nil state initializer",
-			component: mustNew("c1").WithInitialState(nil),
+			component: mustNew("c1", WithInitialState(nil)),
 			wantState: NewState(),
 		},
 	}
@@ -90,7 +90,7 @@ func TestComponent_ResetState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := mustNew("comp").WithInitialState(tt.initState)
+			c := mustNew("comp", WithInitialState(tt.initState))
 			if tt.assertions != nil {
 				tt.assertions(t, c)
 			}

--- a/cycle/cycle.go
+++ b/cycle/cycle.go
@@ -92,8 +92,8 @@ func (c *Cycle) Labels() *meta.Labels {
 	return c.labels
 }
 
-// WithLabel adds or updates a single label.
-func (c *Cycle) WithLabel(name, value string) *Cycle {
+// AddLabel adds or updates a single label.
+func (c *Cycle) AddLabel(name, value string) *Cycle {
 	c.labels.Set(name, value)
 	return c
 }
@@ -103,8 +103,8 @@ func (c *Cycle) Scalars() *meta.Scalars {
 	return c.scalars
 }
 
-// WithScalar adds or updates a single scalar.
-func (c *Cycle) WithScalar(name string, value float64) *Cycle {
+// AddScalar adds or updates a single scalar.
+func (c *Cycle) AddScalar(name string, value float64) *Cycle {
 	c.scalars.Set(name, value)
 	return c
 }

--- a/fmesh.go
+++ b/fmesh.go
@@ -65,10 +65,12 @@ func (fm *FMesh) ComponentByName(name string) *component.Component {
 	return fm.Components().ByName(name)
 }
 
-// SetDescription sets a description.
-func (fm *FMesh) SetDescription(description string) *FMesh {
-	fm.description = description
-	return fm
+// WithDescription is a constructor option that sets a description on the mesh.
+func WithDescription(description string) Option {
+	return func(fm *FMesh) error {
+		fm.description = description
+		return nil
+	}
 }
 
 // Labels returns the mesh's labels store.
@@ -141,16 +143,16 @@ func (fm *FMesh) RemoveScalars(names ...string) *FMesh {
 	return fm
 }
 
-// WithLabelOption is a constructor option that adds or updates a single label on the mesh.
-func WithLabelOption(name, value string) Option {
+// WithLabel is a constructor option that adds or updates a single label on the mesh.
+func WithLabel(name, value string) Option {
 	return func(fm *FMesh) error {
 		fm.labels.Set(name, value)
 		return nil
 	}
 }
 
-// WithScalarOption is a constructor option that adds or updates a single scalar on the mesh.
-func WithScalarOption(name string, value float64) Option {
+// WithScalar is a constructor option that adds or updates a single scalar on the mesh.
+func WithScalar(name string, value float64) Option {
 	return func(fm *FMesh) error {
 		fm.scalars.Set(name, value)
 		return nil
@@ -166,7 +168,7 @@ func (fm *FMesh) AddComponents(components ...*component.Component) error {
 
 		// Inherit logger from fm if the component does not have its own
 		if c.Logger() == nil {
-			c.WithLogger(fm.Logger())
+			c.SetLogger(fm.Logger())
 		}
 
 		c.SetParentMesh(fm)

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -91,37 +91,20 @@ func TestNew(t *testing.T) {
 }
 
 func TestFMesh_WithDescription(t *testing.T) {
-	tests := []struct {
-		name        string
-		fm          *FMesh
-		description string
-		assertions  func(t *testing.T, fm *FMesh)
-	}{
-		{
-			name:        "empty description",
-			fm:          mustNewFMesh("fm1"),
-			description: "",
-			assertions: func(t *testing.T, fm *FMesh) {
-				assert.Empty(t, fm.Description())
-			},
-		},
-		{
-			name:        "with description",
-			fm:          mustNewFMesh("fm1"),
-			description: "descr",
-			assertions: func(t *testing.T, fm *FMesh) {
-				assert.Equal(t, "descr", fm.Description())
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.fm.SetDescription(tt.description)
-			if tt.assertions != nil {
-				tt.assertions(t, got)
-			}
-		})
-	}
+	t.Run("empty description", func(t *testing.T) {
+		fm := mustNewFMesh("fm1")
+		assert.Empty(t, fm.Description())
+	})
+
+	t.Run("with description", func(t *testing.T) {
+		fm := mustNewFMesh("fm1", WithDescription("descr"))
+		assert.Equal(t, "descr", fm.Description())
+	})
+
+	t.Run("WithDescription replaces previous value", func(t *testing.T) {
+		fm := mustNewFMesh("fm1", WithDescription("first"), WithDescription("second"))
+		assert.Equal(t, "second", fm.Description())
+	})
 }
 
 func TestFMesh_WithConfig(t *testing.T) {
@@ -365,7 +348,7 @@ func TestFMesh_AddComponents(t *testing.T) {
 			fm:   mustNewFMesh("fm1"),
 			args: args{
 				components: []*component.Component{
-					mustNewComponent("c1").SetActivationFunc(noOpActivationFunc),
+					mustNewComponent("c1", component.WithActivationFunc(noOpActivationFunc)),
 				},
 			},
 			assertions: func(t *testing.T, fm *FMesh) {
@@ -378,8 +361,8 @@ func TestFMesh_AddComponents(t *testing.T) {
 			fm:   mustNewFMesh("fm1"),
 			args: args{
 				components: []*component.Component{
-					mustNewComponent("c1").SetActivationFunc(noOpActivationFunc),
-					mustNewComponent("c2").SetActivationFunc(noOpActivationFunc),
+					mustNewComponent("c1", component.WithActivationFunc(noOpActivationFunc)),
+					mustNewComponent("c2", component.WithActivationFunc(noOpActivationFunc)),
 				},
 			},
 			assertions: func(t *testing.T, fm *FMesh) {
@@ -393,8 +376,8 @@ func TestFMesh_AddComponents(t *testing.T) {
 			fm:   mustNewFMesh("fm1"),
 			args: args{
 				components: []*component.Component{
-					mustNewComponent("c1").SetActivationFunc(noOpActivationFunc),
-					mustNewComponent("c1").SetActivationFunc(noOpActivationFunc),
+					mustNewComponent("c1", component.WithActivationFunc(noOpActivationFunc)),
+					mustNewComponent("c1", component.WithActivationFunc(noOpActivationFunc)),
 				},
 			},
 			wantErr:    true,
@@ -405,8 +388,8 @@ func TestFMesh_AddComponents(t *testing.T) {
 			fm:   mustNewFMesh("fm1"),
 			args: args{
 				components: []*component.Component{
-					mustNewComponent("c1").SetActivationFunc(noOpActivationFunc),                                                          // Must get default logger
-					mustNewComponent("c2").SetActivationFunc(noOpActivationFunc).WithLogger(log.New(io.Discard, "custom", log.LstdFlags)), // Must not be overridden by fmesh
+					mustNewComponent("c1", component.WithActivationFunc(noOpActivationFunc)),                                                                     // Must get default logger
+					mustNewComponent("c2", component.WithActivationFunc(noOpActivationFunc), component.WithLogger(log.New(io.Discard, "custom", log.LstdFlags))), // Must not be overridden by fmesh
 				},
 			},
 			assertions: func(t *testing.T, fm *FMesh) {
@@ -426,7 +409,7 @@ func TestFMesh_AddComponents(t *testing.T) {
 			fm:   mustNewFMesh("fm1"),
 			args: args{
 				components: []*component.Component{
-					mustNewComponent("c1").SetDescription("No AF"),
+					mustNewComponent("c1", component.WithDescription("No AF")),
 				},
 			},
 			wantErr:    true,
@@ -473,11 +456,14 @@ func TestFMesh_Run(t *testing.T) {
 					CyclesLimit:           0,
 				}))
 				require.NoError(t, fm.AddComponents(
-					mustAddOutputs(mustAddInputs(mustNewComponent("c1").
-						SetDescription("This component simply puts a constant on o1"), "i1"), "o1").
-						SetActivationFunc(func(this *component.Component) error {
+					mustNewComponent("c1",
+						component.WithInputs("i1"),
+						component.WithOutputs("o1"),
+						component.WithDescription("This component simply puts a constant on o1"),
+						component.WithActivationFunc(func(this *component.Component) error {
 							return this.OutputByName("o1").PutSignals(signal.New(77))
 						}),
+					),
 				))
 				return fm
 			},
@@ -500,11 +486,13 @@ func TestFMesh_Run(t *testing.T) {
 					ErrorHandlingStrategy: StopOnFirstErrorOrPanic,
 				}))
 				require.NoError(t, fm.AddComponents(
-					mustAddInputs(mustNewComponent("c1").
-						SetDescription("This component just returns an unexpected error"), "i1").
-						SetActivationFunc(func(this *component.Component) error {
+					mustNewComponent("c1",
+						component.WithInputs("i1"),
+						component.WithDescription("This component just returns an unexpected error"),
+						component.WithActivationFunc(func(this *component.Component) error {
 							return errors.New("boom")
 						}),
+					),
 				))
 				return fm
 			},
@@ -532,12 +520,13 @@ func TestFMesh_Run(t *testing.T) {
 					mustNewComponent("c1",
 						component.WithInputs("i1", "i2"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component waits until it gets signals on both inputs"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							if !this.Inputs().ByNames("i1", "i2").AllHaveSignals() {
 								return component.ErrWaitingForInputs
 							}
 							return this.OutputByName("o1").PutSignals(signal.New("done"))
-						})).SetDescription("This component waits until it gets signals on both inputs"),
+						})),
 				))
 				return fm
 			},
@@ -577,6 +566,7 @@ func TestFMesh_Run(t *testing.T) {
 					mustNewComponent("c1",
 						component.WithInputs("trigger", "loop_in"),
 						component.WithOutputs("loop_out", "num1", "num2"),
+						component.WithDescription("Loops back into itself, routing odd counts to num1 and even counts to num2"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							count := this.InputByName("loop_in").Signals().FirstPayloadOrDefault(0).(int)
 							count++
@@ -597,10 +587,11 @@ func TestFMesh_Run(t *testing.T) {
 								}
 							}
 							return nil
-						})).SetDescription("Loops back into itself, routing odd counts to num1 and even counts to num2"),
+						})),
 					mustNewComponent("c2",
 						component.WithInputs("in1", "in2"),
 						component.WithOutputs("result"),
+						component.WithDescription("Waits for both inputs (keeping signals) then multiplies them"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							if !this.Inputs().ByNames("in1", "in2").AllHaveSignals() {
 								return component.ErrWaitingForInputsKeep
@@ -608,7 +599,7 @@ func TestFMesh_Run(t *testing.T) {
 							a := this.InputByName("in1").Signals().FirstPayloadOrDefault(0).(int)
 							b := this.InputByName("in2").Signals().FirstPayloadOrDefault(0).(int)
 							return this.OutputByName("result").PutPayloads(a * b)
-						})).SetDescription("Waits for both inputs (keeping signals) then multiplies them"),
+						})),
 				))
 				return fm
 			},
@@ -658,27 +649,31 @@ func TestFMesh_Run(t *testing.T) {
 					mustNewComponent("c1",
 						component.WithInputs("i1"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component just sends a number to c2"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							return this.OutputByName("o1").PutSignals(signal.New(10))
-						})).SetDescription("This component just sends a number to c2"),
+						})),
 					mustNewComponent("c2",
 						component.WithInputs("i1"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component receives a number from c1 and passes it to c4"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							return port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))
-						})).SetDescription("This component receives a number from c1 and passes it to c4"),
+						})),
 					mustNewComponent("c3",
 						component.WithInputs("i1"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component returns an error, but the mesh is configured to ignore errors"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							return errors.New("boom")
-						})).SetDescription("This component returns an error, but the mesh is configured to ignore errors"),
+						})),
 					mustNewComponent("c4",
 						component.WithInputs("i1"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component receives a number from c2 and panics"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							panic("no way")
-						})).SetDescription("This component receives a number from c2 and panics"),
+						})),
 				))
 				return fm
 			},
@@ -753,38 +748,43 @@ func TestFMesh_Run(t *testing.T) {
 					mustNewComponent("c1",
 						component.WithInputs("i1"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component just sends a number to c2"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							return this.OutputByName("o1").PutSignals(signal.New(10))
-						})).SetDescription("This component just sends a number to c2"),
+						})),
 					mustNewComponent("c2",
 						component.WithInputs("i1"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component receives a number from c1 and passes it to c4"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							_ = port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))
 							return nil
-						})).SetDescription("This component receives a number from c1 and passes it to c4"),
+						})),
 					mustNewComponent("c3",
 						component.WithInputs("i1"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component returns an error, but the mesh is configured to ignore errors"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							return errors.New("boom")
-						})).SetDescription("This component returns an error, but the mesh is configured to ignore errors"),
+						})),
 					mustNewComponent("c4",
 						component.WithInputs("i1"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component receives a number from c2 and panics, but the mesh is configured to ignore even panics"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							_ = port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))
 
 							// Even component panicked, it managed to set some data on output "o1"
 							// so that data will be available in next cycle
 							panic("no way")
-						})).SetDescription("This component receives a number from c2 and panics, but the mesh is configured to ignore even panics"),
+						})),
 					mustNewComponent("c5",
 						component.WithInputs("i1"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component receives a number from c4"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							return port.ForwardSignals(this.InputByName("i1"), this.OutputByName("o1"))
-						})).SetDescription("This component receives a number from c4"),
+						})),
 				))
 				return fm
 			},

--- a/integration_tests/chainability/chainability_test.go
+++ b/integration_tests/chainability/chainability_test.go
@@ -32,8 +32,8 @@ func TestChainability_CrossPackage(t *testing.T) {
 		c := mustComponent("processor",
 			component.WithInputs("in1", "in2"),
 			component.WithOutputs("out1", "out2"),
+			component.WithDescription("main processor"),
 		).
-			SetDescription("main processor").
 			AddLabel("env", "prod").
 			AddLabel("tier", "backend").
 			SetLabels(map[string]string{"reset": "true"}). // Reset all labels
@@ -78,8 +78,8 @@ func TestChainability_CrossPackage(t *testing.T) {
 		c := mustComponent("worker",
 			component.WithInputs("tasks"),
 			component.WithOutputs("results"),
+			component.WithDescription("background worker"),
 		).
-			SetDescription("background worker").
 			AddLabels(map[string]string{
 				"env":      "prod",
 				"team":     "backend",
@@ -147,8 +147,8 @@ func TestChainability_CrossPackage(t *testing.T) {
 		c := mustComponent("api-handler",
 			component.WithInputs("request"),
 			component.WithOutputs("response", "errors"),
+			component.WithDescription("HTTP API handler"),
 		).
-			SetDescription("HTTP API handler").
 			AddLabels(map[string]string{
 				"env":  "dev",
 				"team": "platform",

--- a/integration_tests/component_hooks/basic_test.go
+++ b/integration_tests/component_hooks/basic_test.go
@@ -34,6 +34,9 @@ func TestComponentHooks_AllTypes(t *testing.T) {
 	c := mustComponent("processor",
 		component.WithInputs("in"),
 		component.WithOutputs("out"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return c.OutputByName("out").PutSignals(signal.New(42))
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.BeforeActivation(func(c *component.Component) error {
 			executionLog = append(executionLog, "before")
@@ -49,8 +52,6 @@ func TestComponentHooks_AllTypes(t *testing.T) {
 			executionLog = append(executionLog, "after")
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return c.OutputByName("out").PutSignals(signal.New(42))
 	})
 
 	require.NoError(t, c.InputByName("in").PutSignals(signal.New(1)))
@@ -68,6 +69,9 @@ func TestComponentHooks_OnError(t *testing.T) {
 
 	c := mustComponent("processor",
 		component.WithInputs("in"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return testErr
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.OnError(func(ctx *component.ActivationContext) error {
 			errorCaught = true
@@ -80,8 +84,6 @@ func TestComponentHooks_OnError(t *testing.T) {
 			afterFired = true
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return testErr
 	})
 
 	require.NoError(t, c.InputByName("in").PutSignals(signal.New(1)))
@@ -99,6 +101,9 @@ func TestComponentHooks_OnPanic(t *testing.T) {
 
 	c := mustComponent("processor",
 		component.WithInputs("in"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			panic("oh no!")
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.OnPanic(func(ctx *component.ActivationContext) error {
 			panicCaught = true
@@ -111,8 +116,6 @@ func TestComponentHooks_OnPanic(t *testing.T) {
 			afterFired = true
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		panic("oh no!")
 	})
 
 	require.NoError(t, c.InputByName("in").PutSignals(signal.New(1)))
@@ -129,18 +132,19 @@ func TestComponentHooks_OnWaitingForInputs(t *testing.T) {
 
 	c := mustComponent("processor",
 		component.WithInputs("data", "config"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			// Wait for config input
+			if !c.InputByName("config").Signals().Any(func(s *signal.Signal) bool { return true }) {
+				return component.ErrWaitingForInputs
+			}
+			return nil
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.OnWaitingForInputs(func(ctx *component.ActivationContext) error {
 			waitingCaught = true
 			assert.Equal(t, component.ActivationCodeWaitingForInputsClear, ctx.Result.Code())
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		// Wait for config input
-		if !c.InputByName("config").Signals().Any(func(s *signal.Signal) bool { return true }) {
-			return component.ErrWaitingForInputs
-		}
-		return nil
 	})
 
 	// Only provide data input, not config
@@ -156,6 +160,9 @@ func TestComponentHooks_MultipleHooksPerType(t *testing.T) {
 
 	c := mustComponent("processor",
 		component.WithInputs("in"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return nil
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.BeforeActivation(func(c *component.Component) error {
 			log = append(log, "before1")
@@ -173,8 +180,6 @@ func TestComponentHooks_MultipleHooksPerType(t *testing.T) {
 			log = append(log, "success2")
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return nil
 	})
 
 	require.NoError(t, c.InputByName("in").PutSignals(signal.New(1)))
@@ -188,13 +193,14 @@ func TestComponentHooks_NoHooksOnNoInput(t *testing.T) {
 
 	c := mustComponent("processor",
 		component.WithInputs("in"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return nil
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.BeforeActivation(func(c *component.Component) error {
 			beforeFired = true
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return nil
 	})
 
 	// No input signals provided
@@ -212,6 +218,9 @@ func TestComponentHooks_ContextAccess(t *testing.T) {
 	c := mustComponent("test-component",
 		component.WithInputs("in"),
 		component.WithOutputs("out"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return c.OutputByName("out").PutSignals(signal.New(100))
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.AfterActivation(func(ctx *component.ActivationContext) error {
 			componentName = ctx.Component.Name()
@@ -219,8 +228,6 @@ func TestComponentHooks_ContextAccess(t *testing.T) {
 			assert.Equal(t, 1, ctx.Component.Outputs().ByName("out").Signals().Len())
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return c.OutputByName("out").PutSignals(signal.New(100))
 	})
 
 	require.NoError(t, c.InputByName("in").PutSignals(signal.New(1)))
@@ -236,24 +243,26 @@ func TestComponentHooks_IntegrationWithFMesh(t *testing.T) {
 	c1 := mustComponent("c1",
 		component.WithInputs("in"),
 		component.WithOutputs("out"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return c.OutputByName("out").PutSignals(signal.New(1))
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.BeforeActivation(func(c *component.Component) error {
 			log.add(c.Name())
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return c.OutputByName("out").PutSignals(signal.New(1))
 	})
 
 	c2 := mustComponent("c2",
 		component.WithInputs("in"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return nil
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.BeforeActivation(func(c *component.Component) error {
 			log.add(c.Name())
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return nil
 	})
 
 	require.NoError(t, c1.OutputByName("out").PipeTo(c2.InputByName("in")))
@@ -278,6 +287,9 @@ func TestComponentHooks_ExecutionOrderAcrossComponents(t *testing.T) {
 	c1 := mustComponent("c1",
 		component.WithInputs("in"),
 		component.WithOutputs("out"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return c.OutputByName("out").PutSignals(signal.New(1))
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.BeforeActivation(func(c *component.Component) error {
 			log.add("c1:before")
@@ -291,13 +303,14 @@ func TestComponentHooks_ExecutionOrderAcrossComponents(t *testing.T) {
 			log.add("c1:after")
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return c.OutputByName("out").PutSignals(signal.New(1))
 	})
 
 	c2 := mustComponent("c2",
 		component.WithInputs("in"),
 		component.WithOutputs("out"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return c.OutputByName("out").PutSignals(signal.New(2))
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.BeforeActivation(func(c *component.Component) error {
 			log.add("c2:before")
@@ -311,12 +324,13 @@ func TestComponentHooks_ExecutionOrderAcrossComponents(t *testing.T) {
 			log.add("c2:after")
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return c.OutputByName("out").PutSignals(signal.New(2))
 	})
 
 	c3 := mustComponent("c3",
 		component.WithInputs("in"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return nil
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.BeforeActivation(func(c *component.Component) error {
 			log.add("c3:before")
@@ -330,8 +344,6 @@ func TestComponentHooks_ExecutionOrderAcrossComponents(t *testing.T) {
 			log.add("c3:after")
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return nil
 	})
 
 	// Wire: c1, c2 -> c3 (both feed into c3)
@@ -377,6 +389,9 @@ func TestComponentHooks_MultipleSetupCalls(t *testing.T) {
 	// Multiple SetupHooks calls should accumulate hooks
 	c := mustComponent("processor",
 		component.WithInputs("in"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			return nil
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.BeforeActivation(func(c *component.Component) error {
 			log = append(log, "setup1")
@@ -392,8 +407,6 @@ func TestComponentHooks_MultipleSetupCalls(t *testing.T) {
 			log = append(log, "setup3")
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		return nil
 	})
 
 	require.NoError(t, c.InputByName("in").PutSignals(signal.New(1)))

--- a/integration_tests/computation/basic_test.go
+++ b/integration_tests/computation/basic_test.go
@@ -72,20 +72,22 @@ func Test_Math(t *testing.T) {
 				c1 := mustComponent("c1",
 					component.WithInputs("num"),
 					component.WithOutputs("res"),
+					component.WithDescription("adds 2 to the input"),
 					component.WithActivationFunc(func(this *component.Component) error {
 						num := this.InputByName("num").Signals().FirstPayloadOrNil()
 						return this.OutputByName("res").PutSignals(signal.New(num.(int) + 2))
 					}),
-				).SetDescription("adds 2 to the input")
+				)
 
 				c2 := mustComponent("c2",
 					component.WithInputs("num"),
 					component.WithOutputs("res"),
+					component.WithDescription("multiplies by 3"),
 					component.WithActivationFunc(func(this *component.Component) error {
 						num := this.InputByName("num").Signals().FirstPayloadOrDefault(0)
 						return this.OutputByName("res").PutSignals(signal.New(num.(int) * 3))
 					}),
-				).SetDescription("multiplies by 3")
+				)
 
 				if err := c1.OutputByName("res").PipeTo(c2.InputByName("num")); err != nil {
 					panic(err)
@@ -122,6 +124,7 @@ func Test_Math(t *testing.T) {
 				processor := mustComponent("processor",
 					component.WithInputs("raw_data", "metadata"),
 					component.WithOutputs("logs"),
+					component.WithDescription("processes data using mixed ports"),
 					component.WithActivationFunc(func(this *component.Component) error {
 						// Check if all required inputs have signals
 						if !this.Inputs().AllHaveSignals() {
@@ -143,7 +146,7 @@ func Test_Math(t *testing.T) {
 						return this.OutputByName("logs").PutSignals(signal.New("Processed with metadata: " + metadata))
 						// error port stays empty (no error)
 					}),
-				).SetDescription("processes data using mixed ports")
+				)
 
 				// Add advanced ports
 				if err := processor.AttachInputPorts(

--- a/integration_tests/constraints/time_test.go
+++ b/integration_tests/constraints/time_test.go
@@ -40,6 +40,7 @@ func Test_TimeConstraint(t *testing.T) {
 				ticker := mustComponent("ticker",
 					component.WithInputs("tick_in", "start"),
 					component.WithOutputs("tick_out"),
+					component.WithDescription("simple clock ticking for 10 seconds"),
 					component.WithActivationFunc(func(this *component.Component) error {
 						ticksCount := this.InputByName("tick_in").Signals().FirstPayloadOrDefault(0).(int)
 
@@ -53,7 +54,7 @@ func Test_TimeConstraint(t *testing.T) {
 
 						return this.OutputByName("tick_out").PutSignals(signal.New(ticksCount + 1))
 					}),
-				).SetDescription("simple clock ticking for 10 seconds")
+				)
 
 				if err := ticker.LoopbackPipe("tick_out", "tick_in"); err != nil {
 					panic(err)
@@ -62,8 +63,7 @@ func Test_TimeConstraint(t *testing.T) {
 				fm := mustFMesh("fm", fmesh.WithConfig(fmesh.Config{
 					Debug:     true,
 					TimeLimit: 2 * time.Second,
-				}))
-				fm.SetDescription("this mesh ticks every second for 10 seconds")
+				}), fmesh.WithDescription("this mesh ticks every second for 10 seconds"))
 				if err := fm.AddComponents(ticker); err != nil {
 					panic(err)
 				}
@@ -86,6 +86,7 @@ func Test_TimeConstraint(t *testing.T) {
 				ticker := mustComponent("ticker",
 					component.WithInputs("tick_in", "start"),
 					component.WithOutputs("tick_out"),
+					component.WithDescription("simple clock ticking for 3 seconds"),
 					component.WithActivationFunc(func(this *component.Component) error {
 						ticksCount := this.InputByName("tick_in").Signals().FirstPayloadOrDefault(0).(int)
 
@@ -99,7 +100,7 @@ func Test_TimeConstraint(t *testing.T) {
 
 						return this.OutputByName("tick_out").PutSignals(signal.New(ticksCount + 1))
 					}),
-				).SetDescription("simple clock ticking for 3 seconds")
+				)
 
 				if err := ticker.LoopbackPipe("tick_out", "tick_in"); err != nil {
 					panic(err)
@@ -108,8 +109,7 @@ func Test_TimeConstraint(t *testing.T) {
 				fm := mustFMesh("fm", fmesh.WithConfig(fmesh.Config{
 					Debug:     true,
 					TimeLimit: 0,
-				}))
-				fm.SetDescription("this mesh ticks every second for 10 seconds")
+				}), fmesh.WithDescription("this mesh ticks every second for 10 seconds"))
 				if err := fm.AddComponents(ticker); err != nil {
 					panic(err)
 				}

--- a/integration_tests/errorhandling/orphaned_component_test.go
+++ b/integration_tests/errorhandling/orphaned_component_test.go
@@ -14,24 +14,24 @@ func Test_AllComponentsMustBeRegistered(t *testing.T) {
 		c1, err := component.New("c1",
 			component.WithInputs("num"),
 			component.WithOutputs("res"),
+			component.WithDescription("adds 2 to the input"),
 			component.WithActivationFunc(func(this *component.Component) error {
 				num := this.InputByName("num").Signals().FirstPayloadOrNil()
 				return this.OutputByName("res").PutSignals(signal.New(num.(int) + 2))
 			}),
 		)
 		require.NoError(t, err)
-		c1.SetDescription("adds 2 to the input")
 
 		c2, err := component.New("c2",
 			component.WithInputs("num"),
 			component.WithOutputs("res"),
+			component.WithDescription("multiplies by 3"),
 			component.WithActivationFunc(func(this *component.Component) error {
 				num := this.InputByName("num").Signals().FirstPayloadOrDefault(0)
 				return this.OutputByName("res").PutSignals(signal.New(num.(int) * 3))
 			}),
 		)
 		require.NoError(t, err)
-		c2.SetDescription("multiplies by 3")
 
 		require.NoError(t, c1.OutputByName("res").PipeTo(c2.InputByName("num")))
 

--- a/integration_tests/hooks/component_test.go
+++ b/integration_tests/hooks/component_test.go
@@ -24,6 +24,14 @@ func TestComponentHooks_PracticalErrorLogging(t *testing.T) {
 
 	c := mustComponent("validator",
 		component.WithInputs("data"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			// Simulate validation logic
+			inputVal := c.InputByName("data").Signals().First().PayloadOrDefault(0).(int)
+			if inputVal < 0 {
+				return validationErr
+			}
+			return nil
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.OnError(func(ctx *component.ActivationContext) error {
 			// Access the error and log it with component context
@@ -34,13 +42,6 @@ func TestComponentHooks_PracticalErrorLogging(t *testing.T) {
 			}
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		// Simulate validation logic
-		inputVal := c.InputByName("data").Signals().First().PayloadOrDefault(0).(int)
-		if inputVal < 0 {
-			return validationErr
-		}
-		return nil
 	})
 
 	require.NoError(t, c.InputByName("data").PutSignals(signal.New(-5)))
@@ -60,6 +61,12 @@ func TestComponentHooks_PracticalOutputValidation(t *testing.T) {
 	c := mustComponent("calculator",
 		component.WithInputs("x", "y"),
 		component.WithOutputs("result"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			x := c.InputByName("x").Signals().First().PayloadOrDefault(0).(int)
+			y := c.InputByName("y").Signals().First().PayloadOrDefault(0).(int)
+			result := x + y
+			return c.OutputByName("result").PutSignals(signal.New(result))
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.OnSuccess(func(ctx *component.ActivationContext) error {
 			// Access and validate output signals
@@ -71,11 +78,6 @@ func TestComponentHooks_PracticalOutputValidation(t *testing.T) {
 			}
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		x := c.InputByName("x").Signals().First().PayloadOrDefault(0).(int)
-		y := c.InputByName("y").Signals().First().PayloadOrDefault(0).(int)
-		result := x + y
-		return c.OutputByName("result").PutSignals(signal.New(result))
 	})
 
 	require.NoError(t, c.InputByName("x").PutSignals(signal.New(30)))
@@ -103,6 +105,13 @@ func TestComponentHooks_PracticalMetricsCollection(t *testing.T) {
 	c := mustComponent("processor",
 		component.WithInputs("in"),
 		component.WithOutputs("success", "failure"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			val := c.InputByName("in").Signals().First().PayloadOrDefault(0).(int)
+			if val > 0 {
+				return c.OutputByName("success").PutSignals(signal.New(val * 2))
+			}
+			return errors.New("invalid input")
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.OnSuccess(func(ctx *component.ActivationContext) error {
 			metrics.SuccessCount++
@@ -131,12 +140,6 @@ func TestComponentHooks_PracticalMetricsCollection(t *testing.T) {
 			metrics.TotalActivations++
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		val := c.InputByName("in").Signals().First().PayloadOrDefault(0).(int)
-		if val > 0 {
-			return c.OutputByName("success").PutSignals(signal.New(val * 2))
-		}
-		return errors.New("invalid input")
 	})
 
 	// First activation: success
@@ -163,10 +166,18 @@ func TestComponentHooks_PracticalDataTransformation(t *testing.T) {
 	c := mustComponent("enricher",
 		component.WithInputs("raw"),
 		component.WithOutputs("enriched"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			// Process and output data
+			err := c.InputByName("raw").Signals().ForEach(func(s *signal.Signal) error {
+				processed := s.PayloadOrDefault(0).(int) * 10
+				return c.OutputByName("enriched").PutSignals(signal.New(processed))
+			})
+			return err
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.OnSuccess(func(ctx *component.ActivationContext) error {
 			// Access output and create enriched version with metadata
-			_, err := ctx.Component.OutputByName("enriched").Signals().ForEach(func(s *signal.Signal) error {
+			err := ctx.Component.OutputByName("enriched").Signals().ForEach(func(s *signal.Signal) error {
 				enriched := map[string]any{
 					"value":         s.PayloadOrDefault(nil),
 					"component":     ctx.Component.Name(),
@@ -178,13 +189,6 @@ func TestComponentHooks_PracticalDataTransformation(t *testing.T) {
 			})
 			return err
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		// Process and output data
-		_, err := c.InputByName("raw").Signals().ForEach(func(s *signal.Signal) error {
-			processed := s.PayloadOrDefault(0).(int) * 10
-			return c.OutputByName("enriched").PutSignals(signal.New(processed))
-		})
-		return err
 	})
 
 	require.NoError(t, c.InputByName("raw").PutSignals(signal.New(3), signal.New(7)))
@@ -205,6 +209,13 @@ func TestComponentHooks_PracticalErrorRecovery(t *testing.T) {
 	c := mustComponent("resilient",
 		component.WithInputs("in"),
 		component.WithOutputs("out"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			val := c.InputByName("in").Signals().First().PayloadOrDefault(0).(int)
+			if val == 0 {
+				return errors.New("division by zero")
+			}
+			return c.OutputByName("out").PutSignals(signal.New(100 / val))
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.OnError(func(ctx *component.ActivationContext) error {
 			recoveryAttempted = true
@@ -219,12 +230,6 @@ func TestComponentHooks_PracticalErrorRecovery(t *testing.T) {
 			}
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		val := c.InputByName("in").Signals().First().PayloadOrDefault(0).(int)
-		if val == 0 {
-			return errors.New("division by zero")
-		}
-		return c.OutputByName("out").PutSignals(signal.New(100 / val))
 	})
 
 	require.NoError(t, c.InputByName("in").PutSignals(signal.New(0)))
@@ -248,11 +253,21 @@ func TestComponentHooks_PracticalInputOutputInspection(t *testing.T) {
 	c := mustComponent("aggregator",
 		component.WithInputs("numbers"),
 		component.WithOutputs("sum"),
+		component.WithActivationFunc(func(c *component.Component) error {
+			sum := 0
+			if err := c.InputByName("numbers").Signals().ForEach(func(s *signal.Signal) error {
+				sum += s.PayloadOrDefault(0).(int)
+				return nil
+			}); err != nil {
+				return err
+			}
+			return c.OutputByName("sum").PutSignals(signal.New(sum))
+		}),
 	).SetupHooks(func(h *component.Hooks) {
 		h.BeforeActivation(func(c *component.Component) error {
 			// Capture input state
 			trace.InputCount = c.InputByName("numbers").Signals().Len()
-			_, err := c.InputByName("numbers").Signals().ForEach(func(s *signal.Signal) error {
+			err := c.InputByName("numbers").Signals().ForEach(func(s *signal.Signal) error {
 				trace.InputValues = append(trace.InputValues, s.PayloadOrDefault(0).(int))
 				return nil
 			})
@@ -268,15 +283,6 @@ func TestComponentHooks_PracticalInputOutputInspection(t *testing.T) {
 			}
 			return nil
 		})
-	}).SetActivationFunc(func(c *component.Component) error {
-		sum := 0
-		if _, err := c.InputByName("numbers").Signals().ForEach(func(s *signal.Signal) error {
-			sum += s.PayloadOrDefault(0).(int)
-			return nil
-		}); err != nil {
-			return err
-		}
-		return c.OutputByName("sum").PutSignals(signal.New(sum))
 	})
 
 	require.NoError(t, c.InputByName("numbers").PutSignals(signal.New(10), signal.New(20), signal.New(30)))

--- a/integration_tests/labels/transform_test.go
+++ b/integration_tests/labels/transform_test.go
@@ -112,7 +112,7 @@ func Test_LabelTransformation(t *testing.T) {
 				outPort := this.OutputByName("out")
 
 				// Process each signal and normalize its labels
-				_, err := inPort.Signals().ForEach(func(sig *signal.Signal) error {
+				err := inPort.Signals().ForEach(func(sig *signal.Signal) error {
 					// Normalize label keys to the lowercase
 					normalizedLabels := sig.Labels().Map(func(k, v string) (string, string) {
 						return strings.ToLower(k), v

--- a/integration_tests/meta/meta_test.go
+++ b/integration_tests/meta/meta_test.go
@@ -143,7 +143,7 @@ func Test_ScalarsOnComponents(t *testing.T) {
 		c := mustComponent("proc",
 			component.WithInputs("in"),
 			component.WithOutputs("out"),
-			component.WithScalarOption("version", 2.0),
+			component.WithScalar("version", 2.0),
 		)
 
 		v, ok := c.Scalars().Get("version")
@@ -182,10 +182,10 @@ func Test_ScalarGroupMetadata(t *testing.T) {
 	})
 }
 
-// Test_PortScalarsWithOptions verifies the WithScalarOption port constructor option.
+// Test_PortScalarsWithOptions verifies the WithScalar port constructor option.
 func Test_PortScalarsWithOptions(t *testing.T) {
 	t.Run("port scalars set via constructor option", func(t *testing.T) {
-		p := mustInput("sensor-in", port.WithScalarOption("sample_rate", 100.0))
+		p := mustInput("sensor-in", port.WithScalar("sample_rate", 100.0))
 		v, ok := p.Scalars().Get("sample_rate")
 		require.True(t, ok)
 		assert.InDelta(t, 100.0, v, 1e-9)

--- a/integration_tests/ports/port_creation_test.go
+++ b/integration_tests/ports/port_creation_test.go
@@ -50,8 +50,32 @@ func Test_PortCreationAndManipulation(t *testing.T) {
 		processor := mustComponent("data-processor",
 			component.WithInputs("raw_data", "filter"),
 			component.WithOutputs("processed", "metrics"),
-		).
-			SetDescription("Demonstrates all port creation and manipulation features")
+			component.WithDescription("Demonstrates all port creation and manipulation features"),
+			component.WithActivationFunc(func(this *component.Component) error {
+				// Wait for required inputs
+				if !this.InputByName("raw_data").HasSignals() ||
+					!this.InputByName("config").HasSignals() {
+					return nil
+				}
+
+				// Read inputs
+				data := this.InputByName("raw_data").Signals().FirstPayloadOrDefault("").(string)
+				config := this.InputByName("config").Signals().FirstPayloadOrDefault("").(string)
+				filter := this.InputByName("filter").Signals().FirstPayloadOrDefault("").(string)
+				metadata := this.InputByName("metadata").Signals().FirstPayloadOrDefault("none").(string)
+
+				// Process data
+				result := fmt.Sprintf("[%s:%s] %s (meta: %s)", config, filter, data, metadata)
+
+				// Write outputs
+				if err := this.OutputByName("processed").PutSignals(signal.New(result)); err != nil {
+					return err
+				}
+				return this.OutputByName("metrics").PutSignals(
+					signal.New(fmt.Sprintf("processed %d chars", len(result))),
+				)
+			}),
+		)
 
 		// Advanced API: attach ports with descriptions and labels
 		require.NoError(t, processor.AttachInputPorts(
@@ -66,30 +90,6 @@ func Test_PortCreationAndManipulation(t *testing.T) {
 				AddLabel("severity", "high").
 				AddLabel("format", "structured"),
 		))
-		processor.SetActivationFunc(func(this *component.Component) error {
-			// Wait for required inputs
-			if !this.InputByName("raw_data").HasSignals() ||
-				!this.InputByName("config").HasSignals() {
-				return nil
-			}
-
-			// Read inputs
-			data := this.InputByName("raw_data").Signals().FirstPayloadOrDefault("").(string)
-			config := this.InputByName("config").Signals().FirstPayloadOrDefault("").(string)
-			filter := this.InputByName("filter").Signals().FirstPayloadOrDefault("").(string)
-			metadata := this.InputByName("metadata").Signals().FirstPayloadOrDefault("none").(string)
-
-			// Process data
-			result := fmt.Sprintf("[%s:%s] %s (meta: %s)", config, filter, data, metadata)
-
-			// Write outputs
-			if err := this.OutputByName("processed").PutSignals(signal.New(result)); err != nil {
-				return err
-			}
-			return this.OutputByName("metrics").PutSignals(
-				signal.New(fmt.Sprintf("processed %d chars", len(result))),
-			)
-		})
 
 		// Put signals on all inputs
 		require.NoError(t, processor.InputByName("raw_data").PutSignals(signal.New("test data")))
@@ -158,6 +158,30 @@ func Test_PortCreationAndManipulation(t *testing.T) {
 		// Create a component and manipulate port labels
 		c := mustComponent("label-demo",
 			component.WithOutputs("output"),
+			component.WithActivationFunc(func(this *component.Component) error {
+				if !this.InputByName("input").HasSignals() {
+					return nil
+				}
+
+				// Manipulate port labels during processing
+				inputPort := this.InputByName("input")
+
+				// Add a single label
+				inputPort.AddLabel("processed", "true")
+
+				// Remove specific labels
+				inputPort.RemoveLabels("version")
+
+				// Update labels
+				inputPort.AddLabels(map[string]string{
+					"env":   "prod", // update
+					"build": "123",  // add new
+				})
+
+				// Forward signal to output
+				sig, _ := inputPort.Signals().FirstPayload()
+				return this.OutputByName("output").PutSignals(signal.New(sig))
+			}),
 		)
 		require.NoError(t, c.AttachInputPorts(
 			mustInputPort("input").
@@ -165,30 +189,6 @@ func Test_PortCreationAndManipulation(t *testing.T) {
 				AddLabel("version", "1.0").
 				AddLabel("owner", "team-a"),
 		))
-		c.SetActivationFunc(func(this *component.Component) error {
-			if !this.InputByName("input").HasSignals() {
-				return nil
-			}
-
-			// Manipulate port labels during processing
-			inputPort := this.InputByName("input")
-
-			// Add a single label
-			inputPort.AddLabel("processed", "true")
-
-			// Remove specific labels
-			inputPort.RemoveLabels("version")
-
-			// Update labels
-			inputPort.AddLabels(map[string]string{
-				"env":   "prod", // update
-				"build": "123",  // add new
-			})
-
-			// Forward signal to output
-			sig, _ := inputPort.Signals().FirstPayload()
-			return this.OutputByName("output").PutSignals(signal.New(sig))
-		})
 
 		// Set up and run
 		require.NoError(t, c.InputByName("input").PutSignals(signal.New("data")))
@@ -213,23 +213,23 @@ func Test_PortCreationAndManipulation(t *testing.T) {
 		// Demonstrate adding ports one by one
 		c := mustComponent("incremental",
 			component.WithOutputs("result"),
+			component.WithActivationFunc(func(this *component.Component) error {
+				if !this.Inputs().AllHaveSignals() {
+					return nil
+				}
+
+				a := this.InputByName("a").Signals().FirstPayloadOrDefault(0).(int)
+				b := this.InputByName("b").Signals().FirstPayloadOrDefault(0).(int)
+				cv := this.InputByName("c").Signals().FirstPayloadOrDefault(0).(int)
+
+				return this.OutputByName("result").PutSignals(signal.New(a + b + cv))
+			}),
 		)
 		require.NoError(t, c.AddInputs("a"))   // Add first input
 		require.NoError(t, c.AddInputs("b"))   // Add second input
 		require.NoError(t, c.AttachInputPorts( // Add with details
 			mustInputPort("c", port.WithDescription("Third input")),
 		))
-		c.SetActivationFunc(func(this *component.Component) error {
-			if !this.Inputs().AllHaveSignals() {
-				return nil
-			}
-
-			a := this.InputByName("a").Signals().FirstPayloadOrDefault(0).(int)
-			b := this.InputByName("b").Signals().FirstPayloadOrDefault(0).(int)
-			cv := this.InputByName("c").Signals().FirstPayloadOrDefault(0).(int)
-
-			return this.OutputByName("result").PutSignals(signal.New(a + b + cv))
-		})
 
 		// Verify all ports exist and work
 		require.NoError(t, c.InputByName("a").PutSignals(signal.New(1)))
@@ -254,39 +254,39 @@ func Test_PortCreationAndManipulation(t *testing.T) {
 		c := mustComponent("collection-demo",
 			component.WithInputs("i1", "i2", "i3"),
 			component.WithOutputs("summary"),
+			component.WithActivationFunc(func(this *component.Component) error {
+				inputs := this.Inputs()
+
+				// Count ports with signals
+				portsWithSignals := inputs.Filter(func(p *port.Port) bool {
+					return p.HasSignals()
+				}).Len()
+
+				// Find high priority ports
+				highPriorityPorts := inputs.Filter(func(p *port.Port) bool {
+					lbls := p.Labels().All()
+					return lbls["priority"] == "high"
+				})
+
+				// Apply operation to all ports (add processing label)
+				if err := inputs.ForEach(func(p *port.Port) error {
+					p.AddLabel("checked", "true")
+					return nil
+				}); err != nil {
+					return err
+				}
+
+				highPriorityCount := highPriorityPorts.All()
+				summary := fmt.Sprintf("Total: %d, WithSignals: %d, HighPriority: %d",
+					inputs.Len(), portsWithSignals, len(highPriorityCount))
+
+				return this.OutputByName("summary").PutSignals(signal.New(summary))
+			}),
 		)
 		require.NoError(t, c.AttachInputPorts(
 			mustInputPort("i4").AddLabel("priority", "high"),
 			mustInputPort("i5").AddLabel("priority", "low"),
 		))
-		c.SetActivationFunc(func(this *component.Component) error {
-			inputs := this.Inputs()
-
-			// Count ports with signals
-			portsWithSignals := inputs.Filter(func(p *port.Port) bool {
-				return p.HasSignals()
-			}).Len()
-
-			// Find high priority ports
-			highPriorityPorts := inputs.Filter(func(p *port.Port) bool {
-				lbls := p.Labels().All()
-				return lbls["priority"] == "high"
-			})
-
-			// Apply operation to all ports (add processing label)
-			if err := inputs.ForEach(func(p *port.Port) error {
-				p.AddLabel("checked", "true")
-				return nil
-			}); err != nil {
-				return err
-			}
-
-			highPriorityCount := highPriorityPorts.All()
-			summary := fmt.Sprintf("Total: %d, WithSignals: %d, HighPriority: %d",
-				inputs.Len(), portsWithSignals, len(highPriorityCount))
-
-			return this.OutputByName("summary").PutSignals(signal.New(summary))
-		})
 
 		// Put signals on some ports
 		require.NoError(t, c.InputByName("i1").PutSignals(signal.New(1)))

--- a/integration_tests/ports/waiting_for_inputs_test.go
+++ b/integration_tests/ports/waiting_for_inputs_test.go
@@ -25,11 +25,12 @@ func Test_WaitingForInputs(t *testing.T) {
 					return mustComponent(name,
 						component.WithInputs("i1"),
 						component.WithOutputs("o1"),
+						component.WithDescription("This component just doubles the input"),
 						component.WithActivationFunc(func(this *component.Component) error {
 							inputNum := this.InputByName("i1").Signals().FirstPayloadOrDefault(0)
 							return this.OutputByName("o1").PutSignals(signal.New(inputNum.(int) * 2))
 						}),
-					).SetDescription("This component just doubles the input")
+					)
 				}
 
 				d1 := getDoubler("d1")
@@ -41,6 +42,7 @@ func Test_WaitingForInputs(t *testing.T) {
 				s := mustComponent("sum",
 					component.WithInputs("i1", "i2"),
 					component.WithOutputs("o1"),
+					component.WithDescription("This component just sums 2 inputs"),
 					component.WithActivationFunc(func(this *component.Component) error {
 						if !this.Inputs().ByNames("i1", "i2").AllHaveSignals() {
 							return component.ErrWaitingForInputsKeep
@@ -51,7 +53,7 @@ func Test_WaitingForInputs(t *testing.T) {
 
 						return this.OutputByName("o1").PutSignals(signal.New(inputNum1.(int) + inputNum2.(int)))
 					}),
-				).SetDescription("This component just sums 2 inputs")
+				)
 
 				// This chain consists of 3 components: d1->d2->d3
 				if err := d1.OutputByName("o1").PipeTo(d2.InputByName("i1")); err != nil {

--- a/integration_tests/state/basic_test.go
+++ b/integration_tests/state/basic_test.go
@@ -42,6 +42,7 @@ func Test_State(t *testing.T) {
 				producer := mustComponent("producer",
 					component.WithInputs("demand_rate"),
 					component.WithOutputs("signal_out"),
+					component.WithDescription("produces some signals"),
 					component.WithActivationFunc(func(this *component.Component) error {
 						demandRate := this.InputByName("demand_rate").Signals().FirstPayloadOrDefault(1).(int)
 						this.Logger().Println("demand rate= ", demandRate)
@@ -53,11 +54,15 @@ func Test_State(t *testing.T) {
 						}
 						return nil
 					}),
-				).SetDescription("produces some signals")
+				)
 
 				counter := mustComponent("stateful_counter",
 					component.WithInputs("bypass_in"),
 					component.WithOutputs("bypass_out"),
+					component.WithDescription("counts all observed signals and bypasses them down the stream"),
+					component.WithInitialState(func(state component.State) {
+						state.Set("observed_signals_count", 0)
+					}),
 					component.WithActivationFunc(func(this *component.Component) error {
 						count := this.State().Get("observed_signals_count").(int)
 
@@ -72,14 +77,16 @@ func Test_State(t *testing.T) {
 
 						return nil
 					}),
-				).SetDescription("counts all observed signals and bypasses them down the stream").
-					WithInitialState(func(state component.State) {
-						state.Set("observed_signals_count", 0)
-					})
+				)
 
 				consumer := mustComponent("consumer",
 					component.WithInputs("signal_in", "start"),
 					component.WithOutputs("consumed_signals", "demand_rate"),
+					component.WithDescription("consumes signals"),
+					component.WithInitialState(func(state component.State) {
+						// Simulate uneven demand
+						state.Set("demand_shape", []int{3, 70, 22, 1350})
+					}),
 					component.WithActivationFunc(func(this *component.Component) error {
 						demandShape := this.State().Get("demand_shape").([]int)
 						defer func() {
@@ -99,11 +106,7 @@ func Test_State(t *testing.T) {
 						// Consume signals
 						return port.ForwardSignals(this.InputByName("signal_in"), this.OutputByName("consumed_signals"))
 					}),
-				).SetDescription("consumes signals").
-					WithInitialState(func(state component.State) {
-						// Simulate uneven demand
-						state.Set("demand_shape", []int{3, 70, 22, 1350})
-					})
+				)
 
 				if err := producer.OutputByName("signal_out").PipeTo(counter.InputByName("bypass_in")); err != nil {
 					panic(err)

--- a/port/collection.go
+++ b/port/collection.go
@@ -304,14 +304,18 @@ func (c *Collection) Filter(predicate Predicate) *Collection {
 }
 
 // Map returns a new collection with ports transformed by the mapper function.
-func (c *Collection) Map(mapper Mapper) *Collection {
+// Returns an error if a mapped port has a duplicate name.
+func (c *Collection) Map(mapper Mapper) (*Collection, error) {
 	mapped := NewCollection()
 	for _, port := range c.ports {
-		if result := mapper(port); result != nil {
-			_ = mapped.Add(result) // mapper is responsible for returning uniquely-named ports
+		transformedPort := mapper(port)
+		if transformedPort != nil {
+			if err := mapped.Add(transformedPort); err != nil {
+				return nil, err
+			}
 		}
 	}
-	return mapped
+	return mapped, nil
 }
 
 // WithParentComponent sets the parent component on all ports in the collection and returns the collection.

--- a/port/collection_test.go
+++ b/port/collection_test.go
@@ -528,21 +528,23 @@ func TestCollection_Filter(t *testing.T) {
 func TestCollection_Map(t *testing.T) {
 	t.Run("transforms ports", func(t *testing.T) {
 		collection := mustNewCollection(NewGroup("p1", "p2").All()...)
-		mapped := collection.Map(func(p *Port) *Port {
+		mapped, err := collection.Map(func(p *Port) *Port {
 			return mustOutput("mapped_" + p.Name())
 		})
+		require.NoError(t, err)
 		assert.Equal(t, 2, mapped.Len())
 		assert.NotNil(t, mapped.ByName("mapped_p1"))
 	})
 
 	t.Run("filters out nil results", func(t *testing.T) {
 		collection := mustNewCollection(NewGroup("p1", "p2", "p3").All()...)
-		mapped := collection.Map(func(p *Port) *Port {
+		mapped, err := collection.Map(func(p *Port) *Port {
 			if p.Name() == "p2" {
 				return nil
 			}
 			return p
 		})
+		require.NoError(t, err)
 		assert.Equal(t, 2, mapped.Len())
 	})
 }

--- a/port/port.go
+++ b/port/port.go
@@ -184,8 +184,8 @@ func (p *Port) RemoveScalars(names ...string) *Port {
 	return p
 }
 
-// WithScalarOption is a port constructor option that adds or updates a single scalar.
-func WithScalarOption(name string, value float64) Option {
+// WithScalar is a port constructor option that adds or updates a single scalar.
+func WithScalar(name string, value float64) Option {
 	return func(p *Port) error {
 		p.scalars.Set(name, value)
 		return nil

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -20,9 +20,10 @@ func Test_MultipleRun(t *testing.T) {
 			mustNewComponent("bypass",
 				component.WithInputs("in"),
 				component.WithOutputs("out"),
+				component.WithDescription("Bypasses all signals"),
 				component.WithActivationFunc(func(this *component.Component) error {
 					return port.ForwardSignals(this.InputByName("in"), this.OutputByName("out"))
-				})).SetDescription("Bypasses all signals"),
+				})),
 		))
 
 		for i := range 5 {
@@ -43,15 +44,16 @@ func Test_MultipleRun(t *testing.T) {
 			mustNewComponent("counter",
 				component.WithInputs("trigger"),
 				component.WithOutputs("count"),
+				component.WithDescription("Increments internal counter on each activation"),
+				component.WithInitialState(func(state component.State) {
+					state.Set("count", 0)
+				}),
 				component.WithActivationFunc(func(this *component.Component) error {
 					count := this.State().Get("count").(int)
 					count++
 					this.State().Set("count", count)
 					return this.OutputByName("count").PutSignals(signal.New(count))
-				})).SetDescription("Increments internal counter on each activation").
-				WithInitialState(func(state component.State) {
-					state.Set("count", 0)
-				}),
+				})),
 		))
 
 		require.NoError(t, fm.ComponentByName("counter").InputByName("trigger").PutSignals(signal.New("go")))

--- a/signal/group.go
+++ b/signal/group.go
@@ -265,27 +265,26 @@ func (g *Group) Len() int {
 	return len(g.signals)
 }
 
-// ForEach applies the action to each signal.
-// Returns the processed group and the first error encountered (if any).
-func (g *Group) ForEach(action func(*Signal) error) (*Group, error) {
+// ForEach applies the action to each signal. Returns the first error encountered (if any).
+func (g *Group) ForEach(action func(*Signal) error) error {
 	for _, s := range g.signals {
 		if err := action(s); err != nil {
-			return newGroupFromSignals(g.signals), err
+			return err
 		}
 	}
-	return newGroupFromSignals(g.signals), nil
+	return nil
 }
 
 // ForEachIf applies the action only to signals that match the predicate.
-func (g *Group) ForEachIf(predicate Predicate, action func(*Signal) error) (*Group, error) {
+func (g *Group) ForEachIf(predicate Predicate, action func(*Signal) error) error {
 	for _, s := range g.signals {
 		if predicate(s) {
 			if err := action(s); err != nil {
-				return newGroupFromSignals(g.signals), err
+				return err
 			}
 		}
 	}
-	return newGroupFromSignals(g.signals), nil
+	return nil
 }
 
 // Filter returns a new group with signals that pass the predicate.

--- a/signal/group_test.go
+++ b/signal/group_test.go
@@ -768,7 +768,7 @@ func TestGroup_ForEach(t *testing.T) {
 	t.Run("applies action to each signal", func(t *testing.T) {
 		group := NewGroup(1, 2, 3)
 		count := 0
-		_, err := group.ForEach(func(s *Signal) error {
+		err := group.ForEach(func(s *Signal) error {
 			count++
 			return nil
 		})
@@ -778,7 +778,7 @@ func TestGroup_ForEach(t *testing.T) {
 
 	t.Run("stops on error", func(t *testing.T) {
 		group := NewGroup(1, 2, 3)
-		_, err := group.ForEach(func(s *Signal) error {
+		err := group.ForEach(func(s *Signal) error {
 			return assert.AnError
 		})
 		assert.Error(t, err)
@@ -789,7 +789,7 @@ func TestGroup_ForEachIf(t *testing.T) {
 	t.Run("applies action only to matching signals", func(t *testing.T) {
 		group := NewGroup(1, 2, 3, 4)
 		count := 0
-		_, err := group.ForEachIf(
+		err := group.ForEachIf(
 			func(s *Signal) bool {
 				payload, _ := s.Payload()
 				return payload.(int)%2 == 0
@@ -806,7 +806,7 @@ func TestGroup_ForEachIf(t *testing.T) {
 	t.Run("applies action to all when predicate always true", func(t *testing.T) {
 		group := NewGroup(1, 2, 3)
 		count := 0
-		_, err := group.ForEachIf(
+		err := group.ForEachIf(
 			func(s *Signal) bool { return true },
 			func(s *Signal) error { count++; return nil },
 		)
@@ -817,7 +817,7 @@ func TestGroup_ForEachIf(t *testing.T) {
 	t.Run("applies action to none when predicate always false", func(t *testing.T) {
 		group := NewGroup(1, 2, 3)
 		count := 0
-		_, err := group.ForEachIf(
+		err := group.ForEachIf(
 			func(s *Signal) bool { return false },
 			func(s *Signal) error { count++; return nil },
 		)
@@ -827,7 +827,7 @@ func TestGroup_ForEachIf(t *testing.T) {
 
 	t.Run("stops on error", func(t *testing.T) {
 		group := NewGroup(2, 4, 6)
-		_, err := group.ForEachIf(
+		err := group.ForEachIf(
 			func(s *Signal) bool { return true },
 			func(s *Signal) error { return assert.AnError },
 		)

--- a/signal/immutability_test.go
+++ b/signal/immutability_test.go
@@ -102,14 +102,14 @@ func TestGroup_Add_does_not_poison_receiver_on_nil_signal(t *testing.T) {
 
 func TestGroup_ForEach_does_not_poison_receiver_on_error(t *testing.T) {
 	g := NewGroup(1, 2, 3)
-	_, _ = g.ForEach(func(*Signal) error { return errors.New("stop") })
+	_ = g.ForEach(func(*Signal) error { return errors.New("stop") })
 
 	assert.Equal(t, 3, g.Len())
 }
 
 func TestGroup_ForEachIf_does_not_poison_receiver_on_error(t *testing.T) {
 	g := NewGroup(1, 2, 3)
-	_, _ = g.ForEachIf(
+	_ = g.ForEachIf(
 		func(*Signal) bool { return true },
 		func(*Signal) error { return errors.New("stop") },
 	)


### PR DESCRIPTION
This pull request refactors the component construction and mutation API to clarify the distinction between constructor options and post-construction mutators, and to simplify and modernize the naming and usage conventions throughout the codebase and documentation. The changes remove redundant dual-form APIs, update naming conventions, and refactor tests and implementation to align with the new approach.

**API and Naming Convention Updates:**

- Documentation and API now enforce that `With*` is only for constructor options, while `Set*` is reserved for genuine post-construction mutation. Redundant dual-form APIs are removed. (`.agent/docs/naming.md`, `component/activation.go`, `component/component.go`) [[1]](diffhunk://#diff-0afa21f6e8bc4d64825ff6e43a9f5a682695e785017b7604f4b6777aaca5905fL22-R25) [[2]](diffhunk://#diff-0afa21f6e8bc4d64825ff6e43a9f5a682695e785017b7604f4b6777aaca5905fL67-R75) [[3]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L57-L62) [[4]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L133-L157) [[5]](diffhunk://#diff-6bd6ac94a836c73e1550bc234685e67200c3f25d1557f2c82bc9eba480a4e5a0L18-L24)

**Constructor Options and Mutators:**

- Adds or renames constructor options: `WithDescription`, `WithLabel`, `WithScalar`, and `WithLogger` now follow the new conventions. Removes old `WithLabelOption` and `WithScalarOption`. Introduces `SetLogger` as the only post-construction mutator for logger inheritance, and removes other `Set*` methods like `SetDescription` and `SetActivationFunc`. (`component/component.go`, `component/activation.go`) [[1]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L57-L62) [[2]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L133-L157) [[3]](diffhunk://#diff-6bd6ac94a836c73e1550bc234685e67200c3f25d1557f2c82bc9eba480a4e5a0L18-L24)

**Test Refactoring:**

- Refactors all tests to use the new constructor options (`With*`) instead of the removed `Set*` methods, ensuring consistency and clarity in test setup. (`component/activation_test.go`) [[1]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL16-L71) [[2]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL83-R62) [[3]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL99-R78) [[4]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL116-R97) [[5]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL133-R115) [[6]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL151-R134) [[7]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL169-R156) [[8]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL192-R180) [[9]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL215-R202) [[10]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL235-R222) [[11]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL261-R242) [[12]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL280-L283) [[13]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL301-L304) [[14]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL321-R310) [[15]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL343-L346)

**Documentation Improvements:**

- Updates `.agent/docs/naming.md` to clarify naming conventions, remove outdated examples, and provide clear guidance on when to use `With*` vs. `Set*`. Also updates examples to match the new API. [[1]](diffhunk://#diff-0afa21f6e8bc4d64825ff6e43a9f5a682695e785017b7604f4b6777aaca5905fL22-R25) [[2]](diffhunk://#diff-0afa21f6e8bc4d64825ff6e43a9f5a682695e785017b7604f4b6777aaca5905fL67-R75) [[3]](diffhunk://#diff-0afa21f6e8bc4d64825ff6e43a9f5a682695e785017b7604f4b6777aaca5905fL89)

**Internal Cleanup:**

- Removes unused imports and cleans up test files for better maintainability. (`component/component_test.go`)