### PR TITLE
Component plugins can not be duplicated

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -22,6 +22,7 @@ type Component struct {
 	state       State
 	parentMesh  ParentMesh
 	hooks       *Hooks
+	plugins     Plugins
 }
 
 // New creates a new component with the given name and options.
@@ -35,10 +36,17 @@ func New(name string, opts ...Option) (*Component, error) {
 		outputPorts: port.NewCollection(),
 		state:       NewState(),
 		hooks:       NewHooks(),
+		plugins:     NewPlugins(),
 	}
 	for _, opt := range opts {
 		if err := opt(c); err != nil {
 			return nil, fmt.Errorf("component %q option failed: %w", name, err)
+		}
+	}
+
+	for pluginName, plugin := range c.plugins {
+		if err := plugin.Init(c); err != nil {
+			return nil, fmt.Errorf("component %q plugin %s initialization failed: %w", name, pluginName, err)
 		}
 	}
 

--- a/component/plugin.go
+++ b/component/plugin.go
@@ -8,14 +8,28 @@ type Plugin interface {
 	Init(*Component) error
 }
 
-// WithPlugins is a component constructor option that initializes plugins.
+// Plugins defines a container of component plugins.
+type Plugins map[string]Plugin
+
+// NewPlugins is a constructor for Plugins.
+func NewPlugins() Plugins {
+	return make(Plugins)
+}
+
+// WithPlugins is a component constructor option that adds plugins.
 func WithPlugins(plugins ...Plugin) Option {
 	return func(c *Component) error {
 		for _, plugin := range plugins {
-			if err := plugin.Init(c); err != nil {
-				return fmt.Errorf("failed to initialize plugin %s: %w", plugin.GetName(), err)
+			if _, exists := c.plugins[plugin.GetName()]; exists {
+				return fmt.Errorf("plugin %s already registered", plugin.GetName())
 			}
+			c.plugins[plugin.GetName()] = plugin
 		}
 		return nil
 	}
+}
+
+// PluginRegistered returns true if the plugin is registered.
+func (c *Component) PluginRegistered(name string) bool {
+	return c.plugins[name] != nil
 }

--- a/component/plugin_test.go
+++ b/component/plugin_test.go
@@ -48,6 +48,25 @@ func TestComponent_Plugin(t *testing.T) {
 		assert.True(t, c.Labels().ValueIs("plugin/price/version", "v1.2.4"))
 		assert.True(t, c.Scalars().ValueIs("plugin/price/threshold", 105.54))
 	})
+
+	t.Run("plugins can be registered only once", func(t *testing.T) {
+		// Build component
+		c, err := New("dummy",
+			WithInputs("i1"),
+			WithOutputs("o1"),
+			WithDescription("Bypass int from i1 to o1"),
+			WithActivationFunc(func(this *Component) error {
+				i1, _ := this.InputByName("i1").Signals().FirstPayloadOrNil().(int)
+
+				return this.OutputByName("o1").PutPayloads(i1)
+			}),
+			// Attach plugins
+			WithPlugins(PricePlugin{}, PricePlugin{}))
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "plugin PricePlugin already registered")
+		assert.Nil(t, c)
+	})
 }
 
 type PricePlugin struct {


### PR DESCRIPTION
This pull request introduces a new plugin management system for components, making plugin registration more robust and preventing duplicate plugins. The main changes include adding a `Plugins` container to the `Component` struct, updating the plugin registration logic, and enhancing tests to ensure plugins can only be registered once.

**Plugin system enhancements:**

* Added a `Plugins` field to the `Component` struct to store registered plugins (`component/component.go`).
* Introduced the `Plugins` type, a map for managing plugins, along with a `NewPlugins` constructor and a `PluginRegistered` method for checking registration (`component/plugin.go`).

**Plugin registration logic:**

* Updated the `WithPlugins` option to prevent duplicate plugin registration by checking if a plugin with the same name is already registered and returning an error if so (`component/plugin.go`).
* Modified the `New` function to initialize all registered plugins after options are applied, ensuring proper plugin setup (`component/component.go`).

**Testing improvements:**

* Added a test case to verify that attempting to register the same plugin more than once results in an error (`component/plugin_test.go`).