### PR TITLE
Logging refactor

### DIFF
--- a/component/activation.go
+++ b/component/activation.go
@@ -103,3 +103,12 @@ func (c *Component) triggerAfterActivation(result *ActivationResult) {
 			WithActivationError(fmt.Errorf("afterActivation hook failed: %w", err))
 	}
 }
+
+// ValidateBeforeActivating checks if the component is good to be activated.
+func (c *Component) ValidateBeforeActivating() error {
+	if c.ParentMesh() == nil {
+		return errors.New("parent mesh is not set")
+	}
+
+	return nil
+}

--- a/component/activation_test.go
+++ b/component/activation_test.go
@@ -3,7 +3,6 @@ package component
 import (
 	"bytes"
 	"errors"
-	"log"
 	"testing"
 
 	"github.com/hovsep/fmesh/port"
@@ -215,7 +214,7 @@ func TestComponent_MaybeActivate(t *testing.T) {
 				c, err := New("c1",
 					WithInputs("i1"),
 					WithActivationFunc(func(this *Component) error {
-						this.logger.Println("This line must be logged")
+						this.Logger().Println("This line must be logged")
 						return errors.New("test error")
 					}),
 				)
@@ -228,18 +227,19 @@ func TestComponent_MaybeActivate(t *testing.T) {
 				SetActivationCode(ActivationCodeReturnedError).
 				WithActivationError(errors.New("component returned an error: test error")),
 			loggerAssertions: func(t *testing.T, output []byte) {
-				assert.Len(t, output, 2+3+21+24) // lengths of component name, prefix, flags and logged message
+				assert.NotEmpty(t, output)
+				assert.Contains(t, string(output), "c1: This line must be logged")
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := log.Default()
-
 			var loggerOutput bytes.Buffer
-			logger.SetOutput(&loggerOutput)
 
-			gotActivationResult := tt.getComponent().SetLogger(logger).MaybeActivate()
+			component := tt.getComponent()
+			component.Logger().SetOutput(&loggerOutput)
+
+			gotActivationResult := component.MaybeActivate()
 			assert.Equal(t, tt.wantActivationResult.Activated(), gotActivationResult.Activated())
 			assert.Equal(t, tt.wantActivationResult.ComponentName(), gotActivationResult.ComponentName())
 			assert.Equal(t, tt.wantActivationResult.Code(), gotActivationResult.Code())

--- a/component/component.go
+++ b/component/component.go
@@ -34,10 +34,12 @@ func New(name string, opts ...Option) (*Component, error) {
 		scalars:     meta.NewScalars(),
 		inputPorts:  port.NewCollection(),
 		outputPorts: port.NewCollection(),
-		state:       NewState(),
-		hooks:       NewHooks(),
-		plugins:     NewPlugins(),
+		logger:      newDefaultLogger(name),
+		state:       newState(),
+		hooks:       newHooks(),
+		plugins:     newPlugins(),
 	}
+
 	for _, opt := range opts {
 		if err := opt(c); err != nil {
 			return nil, fmt.Errorf("component %q option failed: %w", name, err)
@@ -161,35 +163,6 @@ func WithScalar(name string, value float64) Option {
 	}
 }
 
-// WithLogger is a component constructor option that creates a new logger prefixed with component name.
-func WithLogger(logger *log.Logger) Option {
-	return func(c *Component) error {
-		c.setLogger(logger)
-		return nil
-	}
-}
-
-// SetLogger creates a new logger prefixed with component name and sets it on the component.
-func (c *Component) SetLogger(logger *log.Logger) *Component {
-	c.setLogger(logger)
-	return c
-}
-
-// setLogger is the shared implementation for logger setup with nil-guard and prefix logic.
-func (c *Component) setLogger(logger *log.Logger) {
-	if logger == nil {
-		return
-	}
-
-	prefix := fmt.Sprintf("%s: %s ", c.Name(), logger.Prefix())
-	c.logger = log.New(logger.Writer(), prefix, logger.Flags())
-}
-
-// Logger returns the component's logger.
-func (c *Component) Logger() *log.Logger {
-	return c.logger
-}
-
 // ParentMesh returns the component's parent mesh.
 func (c *Component) ParentMesh() ParentMesh {
 	return c.parentMesh
@@ -201,26 +174,10 @@ func (c *Component) SetParentMesh(parentMesh ParentMesh) *Component {
 	return c
 }
 
-// SetupHooks configures hooks for the component using a closure.
-// All hook registration happens inside the provided function.
-func (c *Component) SetupHooks(configure func(*Hooks)) *Component {
-	configure(c.hooks)
-	return c
-}
-
 // ValidateBeforeAddingToMesh checks if the component is good to be added into mesh.
 func (c *Component) ValidateBeforeAddingToMesh() error {
 	if c.f == nil {
 		return errors.New("activation function is not set")
-	}
-
-	return nil
-}
-
-// ValidateBeforeActivating checks if the component is good to be activated.
-func (c *Component) ValidateBeforeActivating() error {
-	if c.ParentMesh() == nil {
-		return errors.New("parent mesh is not set")
 	}
 
 	return nil

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"io"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,27 +12,72 @@ import (
 func TestNewComponent(t *testing.T) {
 	type args struct {
 		name string
+		opts []Option
 	}
 	tests := []struct {
-		name string
-		args args
+		name       string
+		args       args
+		assertions func(t *testing.T, c *Component, err error)
 	}{
 		{
 			name: "empty name is valid",
 			args: args{name: ""},
+			assertions: func(t *testing.T, c *Component, err error) {
+				require.NoError(t, err)
+				assert.NotNil(t, c)
+				assert.Empty(t, c.Name())
+			},
 		},
 		{
 			name: "with name",
 			args: args{name: "multiplier"},
+			assertions: func(t *testing.T, c *Component, err error) {
+				require.NoError(t, err)
+				assert.NotNil(t, c)
+				assert.Equal(t, "multiplier", c.Name())
+			},
+		},
+		{
+			name: "with custom logger",
+			args: args{
+				name: "with-logger",
+				opts: []Option{
+					WithLogger(log.New(io.Discard, "custom-prefix:", log.LstdFlags|log.Lmsgprefix)),
+				},
+			},
+			assertions: func(t *testing.T, c *Component, err error) {
+				require.NoError(t, err)
+				assert.NotNil(t, c)
+				assert.NotNil(t, c.Logger())
+				assert.Equal(t, "custom-prefix:", c.Logger().Prefix())
+			},
+		},
+		{
+			name: "with onCreation hook",
+			args: args{
+				name: "with-hook",
+				opts: []Option{
+					WithHooks(func(hooks *Hooks) {
+						hooks.OnCreation(func(component *Component) error {
+							component.AddLabel("tagging-source", "hook")
+							return nil
+						})
+					}),
+				},
+			},
+			assertions: func(t *testing.T, c *Component, err error) {
+				require.NoError(t, err)
+				assert.NotNil(t, c)
+				assert.Equal(t, "hook", c.Labels().ValueOrDefault("tagging-source", "default"))
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c1, err := New(tt.args.name)
-			require.NoError(t, err)
-			c2, err := New(tt.args.name)
-			require.NoError(t, err)
-			assert.Equal(t, c1, c2)
+			c, err := New(tt.args.name, tt.args.opts...)
+			if tt.assertions != nil {
+				tt.assertions(t, c, err)
+			}
 		})
 	}
 }

--- a/component/hooks.go
+++ b/component/hooks.go
@@ -20,8 +20,8 @@ type Hooks struct {
 	afterActivation    *hook.Group[*ActivationContext]
 }
 
-// NewHooks creates a new hooks registry.
-func NewHooks() *Hooks {
+// newHooks creates a new hooks registry.
+func newHooks() *Hooks {
 	return &Hooks{
 		onCreation:         hook.NewGroup[*Component](),
 		beforeActivation:   hook.NewGroup[*Component](),
@@ -88,4 +88,19 @@ func (h *Hooks) OnWaitingForInputs(fn func(*ActivationContext) error) *Hooks {
 func (h *Hooks) AfterActivation(fn func(*ActivationContext) error) *Hooks {
 	h.afterActivation.Add(fn)
 	return h
+}
+
+// SetupHooks configures hooks for the component using a closure.
+// All hook registration happens inside the provided function.
+func (c *Component) SetupHooks(configure func(*Hooks)) *Component {
+	configure(c.hooks)
+	return c
+}
+
+// WithHooks allows setting hooks during component creation.
+func WithHooks(configure func(*Hooks)) Option {
+	return func(c *Component) error {
+		c.SetupHooks(configure)
+		return nil
+	}
 }

--- a/component/logging.go
+++ b/component/logging.go
@@ -1,14 +1,14 @@
 package component
 
 import (
-	"fmt"
+	"errors"
 	"log"
 	"os"
 )
 
 // newDefaultLogger creates a new logger prefixed with component name.
 func newDefaultLogger(componentName string) *log.Logger {
-	return log.New(os.Stdout, fmt.Sprintf("%s: ", componentName), log.LstdFlags|log.Lmsgprefix)
+	return log.New(os.Stdout, componentName+": ", log.LstdFlags|log.Lmsgprefix)
 }
 
 // Logger returns the component's logger.
@@ -19,6 +19,9 @@ func (c *Component) Logger() *log.Logger {
 // WithLogger is a component constructor option that creates a new logger prefixed with component name.
 func WithLogger(logger *log.Logger) Option {
 	return func(c *Component) error {
+		if logger == nil {
+			return errors.New("logger cannot be nil")
+		}
 		c.logger = logger
 		return nil
 	}

--- a/component/logging.go
+++ b/component/logging.go
@@ -6,6 +6,7 @@ import (
 	"os"
 )
 
+// newDefaultLogger creates a new logger prefixed with component name.
 func newDefaultLogger(componentName string) *log.Logger {
 	return log.New(os.Stdout, fmt.Sprintf("%s: ", componentName), log.LstdFlags|log.Lmsgprefix)
 }

--- a/component/logging.go
+++ b/component/logging.go
@@ -1,0 +1,24 @@
+package component
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+func newDefaultLogger(componentName string) *log.Logger {
+	return log.New(os.Stdout, fmt.Sprintf("%s: ", componentName), log.LstdFlags|log.Lmsgprefix)
+}
+
+// Logger returns the component's logger.
+func (c *Component) Logger() *log.Logger {
+	return c.logger
+}
+
+// WithLogger is a component constructor option that creates a new logger prefixed with component name.
+func WithLogger(logger *log.Logger) Option {
+	return func(c *Component) error {
+		c.logger = logger
+		return nil
+	}
+}

--- a/component/plugin.go
+++ b/component/plugin.go
@@ -11,8 +11,8 @@ type Plugin interface {
 // Plugins defines a container of component plugins.
 type Plugins map[string]Plugin
 
-// NewPlugins is a constructor for Plugins.
-func NewPlugins() Plugins {
+// newPlugins is a constructor for Plugins.
+func newPlugins() Plugins {
 	return make(Plugins)
 }
 

--- a/component/state.go
+++ b/component/state.go
@@ -7,8 +7,8 @@ package component
 // and no two instances of the same component exist concurrently.
 type State map[string]any
 
-// NewState creates a new component state.
-func NewState() State {
+// newState creates a new component state.
+func newState() State {
 	return make(State)
 }
 
@@ -29,7 +29,7 @@ func (c *Component) State() State {
 
 // ResetState resets the component state.
 func (c *Component) ResetState() {
-	c.state = NewState()
+	c.state = newState()
 }
 
 // Has checks if the given key exists in the state.

--- a/component/state_test.go
+++ b/component/state_test.go
@@ -15,7 +15,7 @@ func TestComponent_WithInitialState(t *testing.T) {
 		{
 			name:      "no initial state",
 			component: mustNew("c1"),
-			wantState: NewState(),
+			wantState: newState(),
 		},
 		{
 			name: "with initial state",
@@ -35,7 +35,7 @@ func TestComponent_WithInitialState(t *testing.T) {
 		{
 			name:      "with nil state initializer",
 			component: mustNew("c1", WithInitialState(nil)),
-			wantState: NewState(),
+			wantState: newState(),
 		},
 	}
 
@@ -123,7 +123,7 @@ func TestState_Has(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := newState()
 			tt.initState(s)
 			assert.Equal(t, tt.want, s.Has(tt.key))
 		})
@@ -155,7 +155,7 @@ func TestState_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := newState()
 			tt.initState(s)
 			assert.Equal(t, tt.want, s.Get(tt.key))
 		})
@@ -190,7 +190,7 @@ func TestState_GetOrDefault(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := newState()
 			tt.initState(s)
 			assert.Equal(t, tt.want, s.GetOrDefault(tt.key, tt.defVal))
 		})
@@ -223,7 +223,7 @@ func TestState_Delete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := newState()
 			tt.initState(s)
 			s.Delete(tt.key)
 			assert.Equal(t, tt.wantExists, s.Has(tt.key))
@@ -272,7 +272,7 @@ func TestState_GetTyped(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := newState()
 			tt.initState(s)
 
 			fn := func() {
@@ -330,7 +330,7 @@ func TestState_SetIfAbsent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := newState()
 			tt.initState(s)
 			got := s.SetIfAbsent(tt.key, tt.value)
 			assert.Equal(t, tt.wantSet, got)
@@ -375,7 +375,7 @@ func TestState_Upsert(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := newState()
 			tt.initState(s)
 			s.Upsert(tt.key, tt.fn)
 			assert.Equal(t, tt.want, s.Get(tt.key))
@@ -412,7 +412,7 @@ func TestState_Update(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewState()
+			s := newState()
 			tt.initState(s)
 			got := s.Update(tt.key, tt.fn)
 			assert.Equal(t, tt.wantBool, got)

--- a/config.go
+++ b/config.go
@@ -107,8 +107,7 @@ func WithDebug(enabled bool) Option {
 func WithLogger(logger *log.Logger) Option {
 	return func(fm *FMesh) error {
 		if logger == nil {
-			fm.config.Logger = getDefaultLogger()
-			return nil
+			return errors.New("logger cannot be nil")
 		}
 		fm.config.Logger = logger
 		return nil

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package fmesh
 
 import (
 	"errors"
-	"log"
 	"time"
 )
 
@@ -13,8 +12,6 @@ type Config struct {
 
 	// Debug enables debug mode, which logs additional detailed information for troubleshooting and analysis.
 	Debug bool
-
-	Logger *log.Logger
 
 	// CyclesLimit defines the maximum number of activation cycles.
 	// 0 means no limit (use WithUnlimitedCycles to express this explicitly).
@@ -31,7 +28,6 @@ func newDefaultConfig() Config {
 		ErrorHandlingStrategy: StopOnFirstErrorOrPanic,
 		CyclesLimit:           1000,
 		Debug:                 false,
-		Logger:                getDefaultLogger(),
 		TimeLimit:             5 * time.Second,
 	}
 }
@@ -40,9 +36,6 @@ func newDefaultConfig() Config {
 func WithConfig(config Config) Option {
 	return func(fm *FMesh) error {
 		fm.config = config
-		if fm.config.Logger == nil {
-			fm.config.Logger = getDefaultLogger()
-		}
 		return nil
 	}
 }
@@ -99,17 +92,6 @@ func WithUnlimitedTime() Option {
 func WithDebug(enabled bool) Option {
 	return func(fm *FMesh) error {
 		fm.config.Debug = enabled
-		return nil
-	}
-}
-
-// WithLogger is an FMesh option that sets a custom logger.
-func WithLogger(logger *log.Logger) Option {
-	return func(fm *FMesh) error {
-		if logger == nil {
-			return errors.New("logger cannot be nil")
-		}
-		fm.config.Logger = logger
 		return nil
 	}
 }

--- a/fmesh.go
+++ b/fmesh.go
@@ -166,11 +166,6 @@ func (fm *FMesh) AddComponents(components ...*component.Component) error {
 			return fmt.Errorf("failed to add component %q: %w", c.Name(), err)
 		}
 
-		// Inherit logger from fm if the component does not have its own
-		if c.Logger() == nil {
-			c.SetLogger(fm.Logger())
-		}
-
 		c.SetParentMesh(fm)
 
 		if err := fm.components.Add(c); err != nil {

--- a/fmesh.go
+++ b/fmesh.go
@@ -3,6 +3,7 @@ package fmesh
 import (
 	"errors"
 	"fmt"
+	"log"
 	"sync"
 
 	"github.com/hovsep/fmesh/component"
@@ -21,6 +22,7 @@ type FMesh struct {
 	scalars     *meta.Scalars
 	components  *component.Collection
 	runtimeInfo *RuntimeInfo
+	logger      *log.Logger
 	config      Config
 	hooks       *Hooks
 }
@@ -33,9 +35,10 @@ func New(name string, opts ...Option) (*FMesh, error) {
 		labels:      meta.NewLabels(),
 		scalars:     meta.NewScalars(),
 		components:  component.NewCollection(),
-		runtimeInfo: NewRuntimeInfo(),
+		runtimeInfo: newRuntimeInfo(),
+		logger:      newDefaultLogger(name),
 		config:      newDefaultConfig(),
-		hooks:       NewHooks(),
+		hooks:       newHooks(),
 	}
 	for _, opt := range opts {
 		if err := opt(fm); err != nil {
@@ -299,7 +302,7 @@ func (fm *FMesh) cleanUpPreviousRun() error {
 	}
 
 	// Init runtime info
-	fm.runtimeInfo = NewRuntimeInfo()
+	fm.runtimeInfo = newRuntimeInfo()
 	fm.runtimeInfo.MarkStarted()
 	return nil
 }

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -294,28 +294,31 @@ func TestWithLogger(t *testing.T) {
 	tests := []struct {
 		name       string
 		logger     *log.Logger
-		assertions func(t *testing.T, fm *FMesh)
+		assertions func(t *testing.T, fm *FMesh, err error)
 	}{
 		{
 			name:   "sets custom logger",
 			logger: customLogger,
-			assertions: func(t *testing.T, fm *FMesh) {
+			assertions: func(t *testing.T, fm *FMesh, err error) {
+				require.NoError(t, err)
+				assert.NotNil(t, fm)
 				assert.Equal(t, customLogger, fm.config.Logger)
 			},
 		},
 		{
-			name:   "nil falls back to default logger",
+			name:   "logger must not be nil",
 			logger: nil,
-			assertions: func(t *testing.T, fm *FMesh) {
-				assert.NotNil(t, fm.config.Logger)
+			assertions: func(t *testing.T, fm *FMesh, err error) {
+				require.Error(t, err)
+				assert.Nil(t, fm)
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mustNewFMesh("fm1", WithLogger(tt.logger))
+			got, err := New("fm1", WithLogger(tt.logger))
 			if tt.assertions != nil {
-				tt.assertions(t, got)
+				tt.assertions(t, got, err)
 			}
 		})
 	}
@@ -382,27 +385,6 @@ func TestFMesh_AddComponents(t *testing.T) {
 			},
 			wantErr:    true,
 			wantErrMsg: `component with name "c1" already exists`,
-		},
-		{
-			name: "components inherit logger from fmesh when custom one is not set",
-			fm:   mustNewFMesh("fm1"),
-			args: args{
-				components: []*component.Component{
-					mustNewComponent("c1", component.WithActivationFunc(noOpActivationFunc)),                                                                     // Must get default logger
-					mustNewComponent("c2", component.WithActivationFunc(noOpActivationFunc), component.WithLogger(log.New(io.Discard, "custom", log.LstdFlags))), // Must not be overridden by fmesh
-				},
-			},
-			assertions: func(t *testing.T, fm *FMesh) {
-				assert.Equal(t, 2, fm.Components().Len())
-				assert.NotNil(t, fm.ComponentByName("c1"))
-				assert.NotNil(t, fm.ComponentByName("c2"))
-
-				assert.Equal(t, "c1:  ", fm.ComponentByName("c1").Logger().Prefix())
-				assert.NotEqual(t, io.Discard, fm.ComponentByName("c1").Logger().Writer())
-
-				assert.Equal(t, "c2: custom ", fm.ComponentByName("c2").Logger().Prefix())
-				assert.Equal(t, io.Discard, fm.ComponentByName("c2").Logger().Writer())
-			},
 		},
 		{
 			name: "adding invalid component",

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -302,7 +302,7 @@ func TestWithLogger(t *testing.T) {
 			assertions: func(t *testing.T, fm *FMesh, err error) {
 				require.NoError(t, err)
 				assert.NotNil(t, fm)
-				assert.Equal(t, customLogger, fm.config.Logger)
+				assert.Equal(t, customLogger, fm.logger)
 			},
 		},
 		{

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -302,7 +302,7 @@ func TestWithLogger(t *testing.T) {
 			assertions: func(t *testing.T, fm *FMesh, err error) {
 				require.NoError(t, err)
 				assert.NotNil(t, fm)
-				assert.Equal(t, customLogger, fm.logger)
+				assert.Equal(t, customLogger, fm.Logger())
 			},
 		},
 		{

--- a/hooks.go
+++ b/hooks.go
@@ -19,8 +19,8 @@ type Hooks struct {
 	cycleEnd   *hook.Group[*CycleContext]
 }
 
-// NewHooks creates a new hooks registry with empty hook groups.
-func NewHooks() *Hooks {
+// newHooks creates a new hooks registry with empty hook groups.
+func newHooks() *Hooks {
 	return &Hooks{
 		beforeRun:  hook.NewGroup[*FMesh](),
 		afterRun:   hook.NewGroup[*FMesh](),

--- a/logging.go
+++ b/logging.go
@@ -1,20 +1,20 @@
 package fmesh
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"os"
 )
 
-// Logger returns the F-Mesh logger.
+// Logger returns the mesh logger.
 func (fm *FMesh) Logger() *log.Logger {
-	return fm.config.Logger
+	return fm.logger
 }
 
-func getDefaultLogger() *log.Logger {
-	logger := log.Default()
-	logger.SetOutput(os.Stdout)
-	logger.SetFlags(log.LstdFlags | log.Lmsgprefix)
-	return logger
+// newDefaultLogger creates a new logger prefixed with mesh name.
+func newDefaultLogger(meshName string) *log.Logger {
+	return log.New(os.Stdout, fmt.Sprintf("%s: ", meshName), log.LstdFlags|log.Lmsgprefix)
 }
 
 // IsDebug returns true when debug mode is enabled.
@@ -30,4 +30,15 @@ func (fm *FMesh) LogDebug(format string, args ...any) {
 	}
 
 	fm.Logger().Printf("DEBUG: "+format, args...)
+}
+
+// WithLogger is an FMesh option that sets a custom logger.
+func WithLogger(logger *log.Logger) Option {
+	return func(fm *FMesh) error {
+		if logger == nil {
+			return errors.New("logger cannot be nil")
+		}
+		fm.logger = logger
+		return nil
+	}
 }

--- a/logging.go
+++ b/logging.go
@@ -2,7 +2,6 @@ package fmesh
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"os"
 )
@@ -14,7 +13,7 @@ func (fm *FMesh) Logger() *log.Logger {
 
 // newDefaultLogger creates a new logger prefixed with mesh name.
 func newDefaultLogger(meshName string) *log.Logger {
-	return log.New(os.Stdout, fmt.Sprintf("%s: ", meshName), log.LstdFlags|log.Lmsgprefix)
+	return log.New(os.Stdout, meshName+": ", log.LstdFlags|log.Lmsgprefix)
 }
 
 // IsDebug returns true when debug mode is enabled.

--- a/runtime.go
+++ b/runtime.go
@@ -13,8 +13,8 @@ type RuntimeInfo struct {
 	StoppedAt time.Time
 }
 
-// NewRuntimeInfo constructor.
-func NewRuntimeInfo() *RuntimeInfo {
+// newRuntimeInfo constructor.
+func newRuntimeInfo() *RuntimeInfo {
 	return &RuntimeInfo{
 		Cycles: cycle.NewGroup(),
 	}


### PR DESCRIPTION
This pull request refactors the component and mesh logging and hooks infrastructure for improved encapsulation, testability, and consistency. The main changes include moving logger setup and related options to a new file, standardizing naming for internal constructors, and enhancing test coverage for logger and hook configuration. It also removes some redundant or misplaced logger logic from the mesh configuration.

**Logging refactor and improvements:**

* Introduced `component/logging.go` to encapsulate logger creation, access, and the `WithLogger` option for components, moving these responsibilities out of `component.go` and related files. (`[component/logging.goR1-R28](diffhunk://#diff-b610528cf2afe77f78770a8e296df4b061b031f2cd0f3e62d2aca0fbe78e527dR1-R28)`)
* Updated the component constructor (`New`) to use `newDefaultLogger` and removed inline logger setup logic; the logger is now always initialized with a sensible default. (`[component/component.goL37-R42](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L37-R42)`)
* Removed logger-related fields and options from `Config` and mesh-level `WithLogger`, shifting logger configuration to the component level and avoiding logger propagation via mesh config. (`[[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L17-L18)`, `[[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L34)`, `[[3]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L43-L45)`, `[[4]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L105-L116)`)
* Updated tests to use the new logger access pattern and added tests for custom logger configuration in components. (`[[1]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL218-R217)`, `[[2]](diffhunk://#diff-0c7f741e0589bc462c2d4f371bc60d069daa263a6c908fffbf38ac5767ff7dbdL231-R242)`, `[[3]](diffhunk://#diff-95d56827e4fc8e5b3bb6844f548320c59d6a14cc6c6eb5c6449f6b2dc25e5aadR15-R80)`)

**Hooks and options improvements:**

* Standardized internal constructor names (`newHooks`, `newPlugins`, `newState`) and moved their invocations to the correct locations. (`[[1]](diffhunk://#diff-93f1a1d7818571551052562fbba6d35e01b6a55bbbbb9076a7b22676d8e9d1d4L23-R24)`, `[[2]](diffhunk://#diff-59e5339dd1d0a82a936bcd0cf568442d0d66905aeffdc7b8eced6985ee88e330L14-R15)`, `[[3]](diffhunk://#diff-c2c3d848c09efe3b9a03485c0aa106be3057c86778d0183b59d6cb6640690d85L10-R11)`, `[[4]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L37-R42)`)
* Added `WithHooks` and `SetupHooks` as component options and methods, allowing hooks to be configured at construction time and in tests. (`[[1]](diffhunk://#diff-93f1a1d7818571551052562fbba6d35e01b6a55bbbbb9076a7b22676d8e9d1d4R92-R106)`, `[[2]](diffhunk://#diff-95d56827e4fc8e5b3bb6844f548320c59d6a14cc6c6eb5c6449f6b2dc25e5aadR15-R80)`)
* Improved test coverage for hook configuration during component creation. (`[component/component_test.goR15-R80](diffhunk://#diff-95d56827e4fc8e5b3bb6844f548320c59d6a14cc6c6eb5c6449f6b2dc25e5aadR15-R80)`)

**Code consistency and cleanup:**

* Removed duplicate or misplaced methods (e.g., `ValidateBeforeActivating` moved to the correct location, redundant logger and hook setup removed from `component.go`). (`[[1]](diffhunk://#diff-6bd6ac94a836c73e1550bc234685e67200c3f25d1557f2c82bc9eba480a4e5a0R106-R114)`, `[[2]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L164-L192)`, `[[3]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L204-L210)`, `[[4]](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47L219-L227)`)
* Updated all test files to use the new constructor and access patterns for state, hooks, and logger. (`[[1]](diffhunk://#diff-ad22159d61654e983b169fb8b2bc4fa5b92ff12cff26b4cd25dd40afd365b9a9L18-R18)`, `[[2]](diffhunk://#diff-ad22159d61654e983b169fb8b2bc4fa5b92ff12cff26b4cd25dd40afd365b9a9L38-R38)`, `[[3]](diffhunk://#diff-ad22159d61654e983b169fb8b2bc4fa5b92ff12cff26b4cd25dd40afd365b9a9L126-R126)`, `[[4]](diffhunk://#diff-ad22159d61654e983b169fb8b2bc4fa5b92ff12cff26b4cd25dd40afd365b9a9L158-R158)`, `[[5]](diffhunk://#diff-ad22159d61654e983b169fb8b2bc4fa5b92ff12cff26b4cd25dd40afd365b9a9L193-R193)`, `[[6]](diffhunk://#diff-ad22159d61654e983b169fb8b2bc4fa5b92ff12cff26b4cd25dd40afd365b9a9L226-R226)`, `[[7]](diffhunk://#diff-ad22159d61654e983b169fb8b2bc4fa5b92ff12cff26b4cd25dd40afd365b9a9L275-R275)`, `[[8]](diffhunk://#diff-ad22159d61654e983b169fb8b2bc4fa5b92ff12cff26b4cd25dd40afd365b9a9L333-R333)`, `[[9]](diffhunk://#diff-ad22159d61654e983b169fb8b2bc4fa5b92ff12cff26b4cd25dd40afd365b9a9L378-R378)`, `[[10]](diffhunk://#diff-ad22159d61654e983b169fb8b2bc4fa5b92ff12cff26b4cd25dd40afd365b9a9L415-R415)`)

**Mesh struct and initialization changes:**

* The `FMesh` struct now has its own logger field, initialized with `newDefaultLogger`, and the mesh constructor uses the new hooks and runtime info constructors for consistency. (`[[1]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482R25)`, `[[2]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482L36-R41)`)

These changes increase modularity and testability, make logger and hook configuration more explicit and robust, and clean up legacy or misplaced logic.