### PR TITLE
Polish validations

### DIFF
--- a/component/activation.go
+++ b/component/activation.go
@@ -103,12 +103,3 @@ func (c *Component) triggerAfterActivation(result *ActivationResult) {
 			WithActivationError(fmt.Errorf("afterActivation hook failed: %w", err))
 	}
 }
-
-// ValidateBeforeActivating checks if the component is good to be activated.
-func (c *Component) ValidateBeforeActivating() error {
-	if c.ParentMesh() == nil {
-		return errors.New("parent mesh is not set")
-	}
-
-	return nil
-}

--- a/component/component.go
+++ b/component/component.go
@@ -180,5 +180,25 @@ func (c *Component) ValidateBeforeAddingToMesh() error {
 		return errors.New("activation function is not set")
 	}
 
-	return nil
+	if err := c.Inputs().ForEach(func(p *port.Port) error {
+		if p.ParentComponent() == nil {
+			return fmt.Errorf("input port %q has no parent component", p.Name())
+		}
+		if p.ParentComponent() != c {
+			return fmt.Errorf("input port %q has wrong parent component", p.Name())
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return c.Outputs().ForEach(func(p *port.Port) error {
+		if p.ParentComponent() == nil {
+			return fmt.Errorf("output port %q has no parent component", p.Name())
+		}
+		if p.ParentComponent() != c {
+			return fmt.Errorf("output port %q has wrong parent component", p.Name())
+		}
+		return nil
+	})
 }

--- a/component/hooks.go
+++ b/component/hooks.go
@@ -1,6 +1,8 @@
 package component
 
-import "github.com/hovsep/fmesh/hook"
+import (
+	"github.com/hovsep/fmesh/hook"
+)
 
 // ActivationContext provides context for activation hooks.
 type ActivationContext struct {
@@ -20,7 +22,7 @@ type Hooks struct {
 	afterActivation    *hook.Group[*ActivationContext]
 }
 
-// newHooks creates a new hooks registry.
+// newHooks creates a new hook registry.
 func newHooks() *Hooks {
 	return &Hooks{
 		onCreation:         hook.NewGroup[*Component](),

--- a/component/plugin_test.go
+++ b/component/plugin_test.go
@@ -3,7 +3,6 @@ package component
 import (
 	"testing"
 
-	"github.com/hovsep/fmesh/port"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -78,10 +77,8 @@ func (pp PricePlugin) GetName() string {
 
 func (pp PricePlugin) Init(c *Component) error {
 	// Modify component interface (ports)
-	priceIn, _ := port.NewInput("price_in", port.WithDescription("plugins can dynamically add ports"))
-	priceOut, _ := port.NewOutput("price_out")
-	_ = c.Inputs().Add(priceIn)
-	_ = c.Outputs().Add(priceOut)
+	_ = c.AddInputs("price_in")
+	_ = c.AddOutputs("price_out")
 
 	// Plug in to component via hooks
 	c.SetupHooks(func(hooks *Hooks) {

--- a/fmesh.go
+++ b/fmesh.go
@@ -174,6 +174,10 @@ func (fm *FMesh) AddComponents(components ...*component.Component) error {
 		if err := fm.components.Add(c); err != nil {
 			return fmt.Errorf("failed to add component %q to mesh: %w", c.Name(), err)
 		}
+
+		if err := fm.hooks.onComponentAdded.Trigger(&ComponentAddedContext{FMesh: fm, Component: c}); err != nil {
+			return fmt.Errorf("onComponentAdded hook failed for component %q: %w", c.Name(), err)
+		}
 	}
 
 	fm.LogDebug("%d components added to mesh", fm.Components().Len())
@@ -192,8 +196,8 @@ func (fm *FMesh) SetupHooks(configure func(*Hooks)) *FMesh {
 func (fm *FMesh) runCycle() error {
 	newCycle := cycle.New().SetNumber(fm.runtimeInfo.Cycles.Len() + 1)
 
-	if err := fm.hooks.cycleBegin.Trigger(&CycleContext{FMesh: fm, Cycle: newCycle}); err != nil {
-		cycleErr := errors.Join(errFailedToRunCycle, fmt.Errorf("cycleBegin hook failed: %w", err))
+	if err := fm.hooks.beforeCycle.Trigger(&CycleContext{FMesh: fm, Cycle: newCycle}); err != nil {
+		cycleErr := errors.Join(errFailedToRunCycle, fmt.Errorf("beforeCycle hook failed: %w", err))
 		fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(newCycle)
 		return cycleErr
 	}
@@ -226,8 +230,8 @@ func (fm *FMesh) runCycle() error {
 		})
 	}
 
-	if err := fm.hooks.cycleEnd.Trigger(&CycleContext{FMesh: fm, Cycle: newCycle}); err != nil {
-		cycleErr := errors.Join(errFailedToRunCycle, fmt.Errorf("cycleEnd hook failed: %w", err))
+	if err := fm.hooks.afterCycle.Trigger(&CycleContext{FMesh: fm, Cycle: newCycle}); err != nil {
+		cycleErr := errors.Join(errFailedToRunCycle, fmt.Errorf("afterCycle hook failed: %w", err))
 		fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(newCycle)
 		return cycleErr
 	}
@@ -329,11 +333,6 @@ func (fm *FMesh) Run() (ri *RuntimeInfo, runErr error) {
 		return ri, runErr
 	}
 
-	if err := fm.validateBeforeRun(); err != nil {
-		runErr = err
-		return ri, runErr
-	}
-
 	for {
 		cycleErr := fm.runCycle()
 		if cycleErr != nil {
@@ -401,53 +400,4 @@ func (fm *FMesh) mustStop() (bool, error) {
 		fm.LogDebug("going to stop: %s", ErrUnsupportedErrorHandlingStrategy)
 		return true, ErrUnsupportedErrorHandlingStrategy
 	}
-}
-
-// validateBeforeRun does pre-run checks using plain loops (no nested ForEach chains).
-func (fm *FMesh) validateBeforeRun() error {
-	components := fm.Components().All()
-
-	for _, c := range components {
-		if err := c.ValidateBeforeActivating(); err != nil {
-			return fmt.Errorf("invalid component %q: %w", c.Name(), err)
-		}
-
-		if c.ParentMesh() != fm {
-			return fmt.Errorf("component %q has invalid parent mesh", c.Name())
-		}
-
-		outputPorts := c.Outputs().All()
-
-		for _, p := range outputPorts {
-			if err := p.ValidateBeforeActivation(); err != nil {
-				return fmt.Errorf("invalid port %q in component %q: %w", p.Name(), c.Name(), err)
-			}
-
-			if p.ParentComponent() != c {
-				return fmt.Errorf("port %q in component %q has invalid parent component", p.Name(), c.Name())
-			}
-
-			destPorts := p.Pipes().All()
-			for _, destPort := range destPorts {
-				if err := destPort.ValidateBeforeActivation(); err != nil {
-					return fmt.Errorf("invalid pipe destination port %q from port %q: %w", destPort.Name(), p.Name(), err)
-				}
-
-				parent := destPort.ParentComponent()
-				destComponent, ok := parent.(*component.Component)
-				if !ok || destComponent == nil {
-					return fmt.Errorf("destination port %q has invalid parent component", destPort.Name())
-				}
-
-				if err := destComponent.ValidateBeforeActivating(); err != nil {
-					return fmt.Errorf("invalid component %q (destination): %w", destComponent.Name(), err)
-				}
-
-				if destComponent.ParentMesh() != fm {
-					return fmt.Errorf("component %q has invalid parent mesh", destComponent.Name())
-				}
-			}
-		}
-	}
-	return nil
 }

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -1114,7 +1114,7 @@ func TestFMesh_mustStop(t *testing.T) {
 	}
 }
 
-func TestFMesh_validate(t *testing.T) {
+func TestFMesh_validateMeshStructure(t *testing.T) {
 	tests := []struct {
 		name    string
 		getFM   func() *FMesh
@@ -1143,7 +1143,7 @@ func TestFMesh_validate(t *testing.T) {
 				require.NoError(t, fm.components.Add(c))
 				return fm
 			},
-			wantErr: "parent mesh is not set",
+			wantErr: "wrong parent mesh",
 		},
 		{
 			name: "component has invalid parent mesh",
@@ -1157,7 +1157,7 @@ func TestFMesh_validate(t *testing.T) {
 				require.NoError(t, fm.components.Add(c))
 				return fm
 			},
-			wantErr: "invalid parent mesh",
+			wantErr: "wrong parent mesh",
 		},
 		{
 			name: "pipe leads to unregistered port",
@@ -1197,7 +1197,7 @@ func TestFMesh_validate(t *testing.T) {
 				require.NoError(t, fm.AddComponents(c1)) // Only add c1, not c2
 				return fm
 			},
-			wantErr: "parent mesh is not set",
+			wantErr: "different mesh",
 		},
 		{
 			name: "pipe leads to component with invalid parent mesh",
@@ -1225,14 +1225,14 @@ func TestFMesh_validate(t *testing.T) {
 
 				return fm
 			},
-			wantErr: "invalid parent mesh",
+			wantErr: "different mesh",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fm := tt.getFM()
-			err := fm.validateBeforeRun()
+			_, err := fm.Run()
 
 			if tt.wantErr == "" {
 				require.NoError(t, err)

--- a/hooks.go
+++ b/hooks.go
@@ -43,9 +43,11 @@ func newHooks() *Hooks {
 }
 
 func getDefaultBeforeRunHook() func(*FMesh) error {
-	var once sync.Once
+	var (
+		once          sync.Once
+		validationErr error
+	)
 	return func(fm *FMesh) error {
-		var validationErr error
 		once.Do(func() {
 			validationErr = validateMeshStructure(fm)
 		})
@@ -59,6 +61,9 @@ func validateMeshStructure(fm *FMesh) error {
 			return fmt.Errorf("component %q has wrong parent mesh", c.Name())
 		}
 		return c.Outputs().ForEach(func(p *port.Port) error {
+			if p.ParentComponent() != c {
+				return fmt.Errorf("output port %q has wrong parent component in component %q", p.Name(), c.Name())
+			}
 			return p.Pipes().ForEach(func(dest *port.Port) error {
 				parent := dest.ParentComponent()
 				destComponent, ok := parent.(*component.Component)

--- a/hooks.go
+++ b/hooks.go
@@ -1,8 +1,13 @@
 package fmesh
 
 import (
+	"fmt"
+	"sync"
+
+	"github.com/hovsep/fmesh/component"
 	"github.com/hovsep/fmesh/cycle"
 	"github.com/hovsep/fmesh/hook"
+	"github.com/hovsep/fmesh/port"
 )
 
 // CycleContext provides context for cycle-level hooks.
@@ -11,22 +16,69 @@ type CycleContext struct {
 	Cycle *cycle.Cycle
 }
 
-// Hooks is a registry of all hook types for FMesh.
-type Hooks struct {
-	beforeRun  *hook.Group[*FMesh]
-	afterRun   *hook.Group[*FMesh]
-	cycleBegin *hook.Group[*CycleContext]
-	cycleEnd   *hook.Group[*CycleContext]
+// ComponentAddedContext provides context when a component is added to the mesh.
+type ComponentAddedContext struct {
+	FMesh     *FMesh
+	Component *component.Component
 }
 
-// newHooks creates a new hooks registry with empty hook groups.
+// Hooks is a registry of all hook types for FMesh.
+type Hooks struct {
+	onComponentAdded *hook.Group[*ComponentAddedContext]
+	beforeRun        *hook.Group[*FMesh]
+	afterRun         *hook.Group[*FMesh]
+	beforeCycle      *hook.Group[*CycleContext]
+	afterCycle       *hook.Group[*CycleContext]
+}
+
+// newHooks creates a new hooks registry with default hooks.
 func newHooks() *Hooks {
 	return &Hooks{
-		beforeRun:  hook.NewGroup[*FMesh](),
-		afterRun:   hook.NewGroup[*FMesh](),
-		cycleBegin: hook.NewGroup[*CycleContext](),
-		cycleEnd:   hook.NewGroup[*CycleContext](),
+		onComponentAdded: hook.NewGroup[*ComponentAddedContext](),
+		beforeRun:        hook.NewGroup[*FMesh]().Add(getDefaultBeforeRunHook()),
+		afterRun:         hook.NewGroup[*FMesh](),
+		beforeCycle:      hook.NewGroup[*CycleContext](),
+		afterCycle:       hook.NewGroup[*CycleContext](),
 	}
+}
+
+func getDefaultBeforeRunHook() func(*FMesh) error {
+	var once sync.Once
+	return func(fm *FMesh) error {
+		var validationErr error
+		once.Do(func() {
+			validationErr = validateMeshStructure(fm)
+		})
+		return validationErr
+	}
+}
+
+func validateMeshStructure(fm *FMesh) error {
+	return fm.Components().ForEach(func(c *component.Component) error {
+		if c.ParentMesh() != fm {
+			return fmt.Errorf("component %q has wrong parent mesh", c.Name())
+		}
+		return c.Outputs().ForEach(func(p *port.Port) error {
+			return p.Pipes().ForEach(func(dest *port.Port) error {
+				parent := dest.ParentComponent()
+				destComponent, ok := parent.(*component.Component)
+				if !ok || destComponent == nil {
+					return fmt.Errorf("destination port %q has invalid parent component", dest.Name())
+				}
+				if destComponent.ParentMesh() != fm {
+					return fmt.Errorf("destination component %q belongs to a different mesh", destComponent.Name())
+				}
+				return nil
+			})
+		})
+	})
+}
+
+// OnComponentAdded registers a hook called after each component is successfully added to the mesh.
+// Returns the Hooks registry for method chaining.
+func (h *Hooks) OnComponentAdded(fn func(*ComponentAddedContext) error) *Hooks {
+	h.onComponentAdded.Add(fn)
+	return h
 }
 
 // BeforeRun registers a hook to be called before the mesh starts running.
@@ -43,16 +95,16 @@ func (h *Hooks) AfterRun(fn func(*FMesh) error) *Hooks {
 	return h
 }
 
-// CycleBegin registers a hook to be called at the beginning of each cycle.
+// BeforeCycle registers a hook to be called at the beginning of each cycle.
 // Returns the Hooks registry for method chaining.
-func (h *Hooks) CycleBegin(fn func(*CycleContext) error) *Hooks {
-	h.cycleBegin.Add(fn)
+func (h *Hooks) BeforeCycle(fn func(*CycleContext) error) *Hooks {
+	h.beforeCycle.Add(fn)
 	return h
 }
 
-// CycleEnd registers a hook to be called at the end of each cycle.
+// AfterCycle registers a hook to be called at the end of each cycle.
 // Returns the Hooks registry for method chaining.
-func (h *Hooks) CycleEnd(fn func(*CycleContext) error) *Hooks {
-	h.cycleEnd.Add(fn)
+func (h *Hooks) AfterCycle(fn func(*CycleContext) error) *Hooks {
+	h.afterCycle.Add(fn)
 	return h
 }

--- a/integration_tests/hooks/fmesh_test.go
+++ b/integration_tests/hooks/fmesh_test.go
@@ -38,10 +38,15 @@ func TestHooks_AllTypes(t *testing.T) {
 		}),
 	)
 
-	// Create a mesh with all hook types
+	// Create a mesh with all hook types.
+	// Hooks are registered before AddComponents so OnComponentAdded fires.
 	fm := mustFMesh("test-mesh")
-	require.NoError(t, fm.AddComponents(c))
 	fm.SetupHooks(func(h *fmesh.Hooks) {
+		h.OnComponentAdded(func(ctx *fmesh.ComponentAddedContext) error {
+			executionLog = append(executionLog, "componentAdded")
+			return nil
+		})
+
 		h.BeforeRun(func(fm *fmesh.FMesh) error {
 			executionLog = append(executionLog, "beforeRun")
 			return nil
@@ -62,6 +67,7 @@ func TestHooks_AllTypes(t *testing.T) {
 			return nil
 		})
 	})
+	require.NoError(t, fm.AddComponents(c))
 
 	// Add initial input
 	require.NoError(t, fm.ComponentByName("processor").InputByName("in").PutSignals(signal.New(1)))
@@ -70,9 +76,11 @@ func TestHooks_AllTypes(t *testing.T) {
 	_, err := fm.Run()
 	require.NoError(t, err)
 
-	// Verify the exact execution order: beforeRun -> cycles -> afterRun
+	// Verify the exact execution order: componentAdded -> beforeRun -> cycles -> afterRun
+	// OnComponentAdded fires during AddComponents, before BeforeRun.
 	// Cycle hooks fire twice: once for processing, once for completion
 	assert.Equal(t, []string{
+		"componentAdded",
 		"beforeRun",
 		"beforeCycle",
 		"afterCycle",

--- a/integration_tests/hooks/fmesh_test.go
+++ b/integration_tests/hooks/fmesh_test.go
@@ -52,13 +52,13 @@ func TestHooks_AllTypes(t *testing.T) {
 			return nil
 		})
 
-		h.CycleBegin(func(ctx *fmesh.CycleContext) error {
-			executionLog = append(executionLog, "cycleBegin")
+		h.BeforeCycle(func(ctx *fmesh.CycleContext) error {
+			executionLog = append(executionLog, "beforeCycle")
 			return nil
 		})
 
-		h.CycleEnd(func(ctx *fmesh.CycleContext) error {
-			executionLog = append(executionLog, "cycleEnd")
+		h.AfterCycle(func(ctx *fmesh.CycleContext) error {
+			executionLog = append(executionLog, "afterCycle")
 			return nil
 		})
 	})
@@ -74,10 +74,10 @@ func TestHooks_AllTypes(t *testing.T) {
 	// Cycle hooks fire twice: once for processing, once for completion
 	assert.Equal(t, []string{
 		"beforeRun",
-		"cycleBegin",
-		"cycleEnd",
-		"cycleBegin",
-		"cycleEnd",
+		"beforeCycle",
+		"afterCycle",
+		"beforeCycle",
+		"afterCycle",
 		"afterRun",
 	}, executionLog)
 }
@@ -96,7 +96,7 @@ func TestHooks_CycleContext(t *testing.T) {
 	fm := mustFMesh("test-mesh")
 	require.NoError(t, fm.AddComponents(c))
 	fm.SetupHooks(func(h *fmesh.Hooks) {
-		h.CycleBegin(func(ctx *fmesh.CycleContext) error {
+		h.BeforeCycle(func(ctx *fmesh.CycleContext) error {
 			cycleNumbers = append(cycleNumbers, ctx.Cycle.Number())
 			return nil
 		})
@@ -169,7 +169,7 @@ func TestHooks_ContextAccess(t *testing.T) {
 	fm := mustFMesh("my-mesh")
 	require.NoError(t, fm.AddComponents(c))
 	fm.SetupHooks(func(h *fmesh.Hooks) {
-		h.CycleEnd(func(ctx *fmesh.CycleContext) error {
+		h.AfterCycle(func(ctx *fmesh.CycleContext) error {
 			// Access both FMesh and Cycle through context
 			meshName = ctx.FMesh.Name()
 			cycleNumber = ctx.Cycle.Number()
@@ -204,11 +204,11 @@ func TestHooks_FireOncePerCycle(t *testing.T) {
 	fm := mustFMesh("test-mesh")
 	require.NoError(t, fm.AddComponents(c))
 	fm.SetupHooks(func(h *fmesh.Hooks) {
-		h.CycleBegin(func(ctx *fmesh.CycleContext) error {
+		h.BeforeCycle(func(ctx *fmesh.CycleContext) error {
 			beginCount++
 			return nil
 		})
-		h.CycleEnd(func(ctx *fmesh.CycleContext) error {
+		h.AfterCycle(func(ctx *fmesh.CycleContext) error {
 			endCount++
 			return nil
 		})
@@ -223,8 +223,8 @@ func TestHooks_FireOncePerCycle(t *testing.T) {
 
 	// Verify hooks fire exactly once per cycle
 	actualCycles := runtimeInfo.Cycles.Len()
-	assert.Equal(t, actualCycles, beginCount, "CycleBegin should fire once per cycle")
-	assert.Equal(t, actualCycles, endCount, "CycleEnd should fire once per cycle")
+	assert.Equal(t, actualCycles, beginCount, "BeforeCycle should fire once per cycle")
+	assert.Equal(t, actualCycles, endCount, "AfterCycle should fire once per cycle")
 	assert.Equal(t, beginCount, endCount, "Begin and End should fire same number of times")
 }
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -181,8 +181,8 @@ func Test_MultipleRun(t *testing.T) {
 	t.Run("hooks execute correctly across multiple runs", func(t *testing.T) {
 		beforeRunCount := 0
 		afterRunCount := 0
-		cycleBeginCount := 0
-		cycleEndCount := 0
+		beforeCycleCount := 0
+		afterCycleCount := 0
 
 		fm := mustNewFMesh("test fm")
 		fm.SetupHooks(func(h *Hooks) {
@@ -194,12 +194,12 @@ func Test_MultipleRun(t *testing.T) {
 				afterRunCount++
 				return nil
 			})
-			h.CycleBegin(func(ctx *CycleContext) error {
-				cycleBeginCount++
+			h.BeforeCycle(func(ctx *CycleContext) error {
+				beforeCycleCount++
 				return nil
 			})
-			h.CycleEnd(func(ctx *CycleContext) error {
-				cycleEndCount++
+			h.AfterCycle(func(ctx *CycleContext) error {
+				afterCycleCount++
 				return nil
 			})
 		})
@@ -226,8 +226,8 @@ func Test_MultipleRun(t *testing.T) {
 
 		assert.Equal(t, 3, beforeRunCount, "BeforeRun should be called 3 times")
 		assert.Equal(t, 3, afterRunCount, "AfterRun should be called 3 times")
-		assert.Equal(t, 6, cycleBeginCount, "CycleBegin should be called 6 times (2 per run)")
-		assert.Equal(t, 6, cycleEndCount, "CycleEnd should be called 6 times (2 per run)")
+		assert.Equal(t, 6, beforeCycleCount, "BeforeCycle should be called 6 times (2 per run)")
+		assert.Equal(t, 6, afterCycleCount, "AfterCycle should be called 6 times (2 per run)")
 	})
 
 	t.Run("mesh with error handling strategy stops on error", func(t *testing.T) {


### PR DESCRIPTION
This pull request refactors and extends the FMesh hooks system, improves mesh/component validation, and cleans up related code and tests. The main changes include introducing a new `onComponentAdded` hook, consolidating and renaming cycle hooks for clarity, and moving mesh structure validation into a default pre-run hook. Several tests and internal validation logic are updated to align with these changes.

**Hooks system improvements:**

* Added a new `onComponentAdded` hook, allowing registration of functions that run after a component is successfully added to the mesh. (`hooks.go`, `fmesh.go`, Ff018ecdL16R16, [fmesh.goR177-R180](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482R177-R180))
* Renamed cycle hooks from `CycleBegin`/`CycleEnd` to `BeforeCycle`/`AfterCycle` for improved clarity and consistency. All relevant code and tests are updated to use the new names. (`hooks.go`, `fmesh.go`, `integration_tests/hooks/fmesh_test.go`, [[1]](diffhunk://#diff-1e78b0d4947a1f7dc0495d2f0891937e04685b130c028ce4d0e95d277350393eL46-R108) [[2]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482L195-R200) [[3]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482L229-R234) [[4]](diffhunk://#diff-1a2821c142cfd07fce776a68b33dc11a5ba3d149ed4f7f4f1308789bcffdf040L55-R61) [[5]](diffhunk://#diff-1a2821c142cfd07fce776a68b33dc11a5ba3d149ed4f7f4f1308789bcffdf040L77-R80) [[6]](diffhunk://#diff-1a2821c142cfd07fce776a68b33dc11a5ba3d149ed4f7f4f1308789bcffdf040L99-R99) [[7]](diffhunk://#diff-1a2821c142cfd07fce776a68b33dc11a5ba3d149ed4f7f4f1308789bcffdf040L172-R172) [[8]](diffhunk://#diff-1a2821c142cfd07fce776a68b33dc11a5ba3d149ed4f7f4f1308789bcffdf040L207-R211) [[9]](diffhunk://#diff-1a2821c142cfd07fce776a68b33dc11a5ba3d149ed4f7f4f1308789bcffdf040L226-R227) [[10]](diffhunk://#diff-26a8a16a47cd52bf52e0cdbdfd3f54195240d0c5415dd156dfe9bd33f4ec290aL184-R185) [[11]](diffhunk://#diff-26a8a16a47cd52bf52e0cdbdfd3f54195240d0c5415dd156dfe9bd33f4ec290aL197-R202) [[12]](diffhunk://#diff-26a8a16a47cd52bf52e0cdbdfd3f54195240d0c5415dd156dfe9bd33f4ec290aL229-R230)

**Validation logic refactoring:**

* Moved mesh structure validation from a dedicated `validateBeforeRun` method to a default `BeforeRun` hook, simplifying the main run loop and making validation extensible via hooks. (`fmesh.go`, `hooks.go`, [[1]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482L332-L336) [[2]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482L405-L453) [[3]](diffhunk://#diff-1e78b0d4947a1f7dc0495d2f0891937e04685b130c028ce4d0e95d277350393eR19-R81)
* Enhanced `ValidateBeforeAddingToMesh` to check that all input and output ports have the correct parent component, improving component integrity checks. (`component/component.go`, [component/component.goR183-R203](diffhunk://#diff-6f065ffd54f98081ffd548c200264f761067d883b72b315c01ac28ef5a8fce47R183-R203))
* Removed the now-unnecessary `ValidateBeforeActivating` method from `Component`. (`component/activation.go`, [component/activation.goL106-L114](diffhunk://#diff-6bd6ac94a836c73e1550bc234685e67200c3f25d1557f2c82bc9eba480a4e5a0L106-L114))

**Test and documentation updates:**

* Updated and renamed tests to match the new validation logic and error messages, ensuring they reflect the current codebase and error semantics. (`fmesh_test.go`, [[1]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706L1117-R1117) [[2]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706L1146-R1146) [[3]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706L1160-R1160) [[4]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706L1200-R1200) [[5]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706L1228-R1235)
* Updated documentation and comments for hooks and validation methods for clarity and accuracy. (`component/hooks.go`, [component/hooks.goL23-R25](diffhunk://#diff-93f1a1d7818571551052562fbba6d35e01b6a55bbbbb9076a7b22676d8e9d1d4L23-R25))

**Minor code and import cleanups:**

* Cleaned up imports and improved code style in several files. (`component/hooks.go`, `component/plugin_test.go`, `hooks.go`, [[1]](diffhunk://#diff-93f1a1d7818571551052562fbba6d35e01b6a55bbbbb9076a7b22676d8e9d1d4L3-R5) [[2]](diffhunk://#diff-d0393057418fd69401d0369ac39ea92dead8c20ef7b9097a9197c1ed2c1c3d1bL6) [[3]](diffhunk://#diff-d0393057418fd69401d0369ac39ea92dead8c20ef7b9097a9197c1ed2c1c3d1bL81-R81) [[4]](diffhunk://#diff-1e78b0d4947a1f7dc0495d2f0891937e04685b130c028ce4d0e95d277350393eR4-R10)

These changes collectively make the hooks system more flexible and robust, improve validation coverage, and simplify the codebase for future development and testing.