### PR TITLE
Harden signal package: nil-safe mappers, honest Payload, aggregation …

### DIFF
--- a/component/activation.go
+++ b/component/activation.go
@@ -3,6 +3,7 @@ package component
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/hovsep/fmesh/hook"
 )
@@ -34,7 +35,7 @@ func (c *Component) activate() (result *ActivationResult) {
 
 	defer func() {
 		if r := recover(); r != nil {
-			result = c.newActivationResultPanicked(fmt.Errorf("panicked with: %v", r))
+			result = c.newActivationResultPanicked(fmt.Errorf("panicked with: %v, stack: %s", r, debug.Stack()))
 			c.triggerHooksForResult(result, c.hooks.onPanic)
 			c.triggerAfterActivation(result)
 		}
@@ -92,7 +93,7 @@ func (c *Component) buildResultAndTriggerHook(err error) *ActivationResult {
 func (c *Component) triggerHooksForResult(result *ActivationResult, hookGroup *hook.Group[*ActivationContext]) {
 	if err := hookGroup.Trigger(&ActivationContext{Component: c, Result: result}); err != nil {
 		result.SetActivationCode(ActivationCodeHookFailed).
-			WithActivationError(fmt.Errorf("activation hook failed: %w", err))
+			AddActivationError(fmt.Errorf("activation hook failed: %w", err))
 	}
 }
 
@@ -100,6 +101,6 @@ func (c *Component) triggerHooksForResult(result *ActivationResult, hookGroup *h
 func (c *Component) triggerAfterActivation(result *ActivationResult) {
 	if err := c.hooks.afterActivation.Trigger(&ActivationContext{Component: c, Result: result}); err != nil {
 		result.SetActivationCode(ActivationCodeHookFailed).
-			WithActivationError(fmt.Errorf("afterActivation hook failed: %w", err))
+			AddActivationError(fmt.Errorf("afterActivation hook failed: %w", err))
 	}
 }

--- a/component/activation_result.go
+++ b/component/activation_result.go
@@ -125,8 +125,8 @@ func (ar *ActivationResult) SetActivationCode(code ActivationResultCode) *Activa
 	return ar
 }
 
-// WithActivationError appends an error to the activation result's error list and returns the activation result.
-func (ar *ActivationResult) WithActivationError(activationError error) *ActivationResult {
+// AddActivationError appends an error to the activation result's error list and returns the activation result.
+func (ar *ActivationResult) AddActivationError(activationError error) *ActivationResult {
 	ar.activationErrors = append(ar.activationErrors, activationError)
 	return ar
 }
@@ -147,14 +147,14 @@ func (c *Component) newActivationResultReturnedError(err error) *ActivationResul
 	return NewActivationResult(c.Name()).
 		SetActivated(true).
 		SetActivationCode(ActivationCodeReturnedError).
-		WithActivationError(fmt.Errorf("component returned an error: %w", err))
+		AddActivationError(fmt.Errorf("component returned an error: %w", err))
 }
 
 func (c *Component) newActivationResultPanicked(err error) *ActivationResult {
 	return NewActivationResult(c.Name()).
 		SetActivated(true).
 		SetActivationCode(ActivationCodePanicked).
-		WithActivationError(err)
+		AddActivationError(err)
 }
 
 // newActivationResultHookFailed builds a specific activation result for when a hook fails.
@@ -162,7 +162,7 @@ func (c *Component) newActivationResultHookFailed(err error) *ActivationResult {
 	return NewActivationResult(c.Name()).
 		SetActivated(false).
 		SetActivationCode(ActivationCodeHookFailed).
-		WithActivationError(err)
+		AddActivationError(err)
 }
 
 func (c *Component) newActivationResultWaitingForInputs(err error) *ActivationResult {
@@ -173,7 +173,7 @@ func (c *Component) newActivationResultWaitingForInputs(err error) *ActivationRe
 	return NewActivationResult(c.Name()).
 		SetActivated(true).
 		SetActivationCode(activationCode).
-		WithActivationError(err)
+		AddActivationError(err)
 }
 
 // IsWaitingForInput returns true if the component was waiting for inputs.

--- a/component/activation_result_collection_test.go
+++ b/component/activation_result_collection_test.go
@@ -272,7 +272,7 @@ func TestActivationResultCollection_Without(t *testing.T) {
 
 func TestActivationResult_ActivationErrorWithComponentName(t *testing.T) {
 	err := errors.New("activation failed")
-	r := NewActivationResult("my-component").WithActivationError(err)
+	r := NewActivationResult("my-component").AddActivationError(err)
 
 	t.Run("returns error with component name", func(t *testing.T) {
 		wrappedErr := r.ActivationErrorWithComponentName()
@@ -398,7 +398,7 @@ func TestActivationResult_WithActivationError_Accumulates(t *testing.T) {
 	err3 := errors.New("third error")
 
 	t.Run("single error", func(t *testing.T) {
-		r := NewActivationResult("c").WithActivationError(err1)
+		r := NewActivationResult("c").AddActivationError(err1)
 		assert.Len(t, r.ActivationErrors(), 1)
 		require.Error(t, r.ActivationError())
 		assert.ErrorIs(t, r.ActivationError(), err1)
@@ -406,9 +406,9 @@ func TestActivationResult_WithActivationError_Accumulates(t *testing.T) {
 
 	t.Run("multiple errors accumulate", func(t *testing.T) {
 		r := NewActivationResult("c").
-			WithActivationError(err1).
-			WithActivationError(err2).
-			WithActivationError(err3)
+			AddActivationError(err1).
+			AddActivationError(err2).
+			AddActivationError(err3)
 		assert.Len(t, r.ActivationErrors(), 3)
 		require.ErrorIs(t, r.ActivationError(), err1)
 		require.ErrorIs(t, r.ActivationError(), err2)

--- a/component/activation_test.go
+++ b/component/activation_test.go
@@ -81,7 +81,7 @@ func TestComponent_MaybeActivate(t *testing.T) {
 			wantActivationResult: NewActivationResult("c1").
 				SetActivated(true).
 				SetActivationCode(ActivationCodeReturnedError).
-				WithActivationError(errors.New("component returned an error: test error")),
+				AddActivationError(errors.New("component returned an error: test error")),
 		},
 		{
 			name: "activated without error",
@@ -118,7 +118,7 @@ func TestComponent_MaybeActivate(t *testing.T) {
 			wantActivationResult: NewActivationResult("c1").
 				SetActivated(true).
 				SetActivationCode(ActivationCodePanicked).
-				WithActivationError(errors.New("panicked with: oh shrimps")),
+				AddActivationError(errors.New("panicked with: oh shrimps")),
 		},
 		{
 			name: "component panicked with string",
@@ -137,7 +137,7 @@ func TestComponent_MaybeActivate(t *testing.T) {
 			wantActivationResult: NewActivationResult("c1").
 				SetActivated(true).
 				SetActivationCode(ActivationCodePanicked).
-				WithActivationError(errors.New("panicked with: oh shrimps")),
+				AddActivationError(errors.New("panicked with: oh shrimps")),
 		},
 		{
 			name: "component is waiting for inputs",
@@ -225,7 +225,7 @@ func TestComponent_MaybeActivate(t *testing.T) {
 			wantActivationResult: NewActivationResult("c1").
 				SetActivated(true).
 				SetActivationCode(ActivationCodeReturnedError).
-				WithActivationError(errors.New("component returned an error: test error")),
+				AddActivationError(errors.New("component returned an error: test error")),
 			loggerAssertions: func(t *testing.T, output []byte) {
 				assert.NotEmpty(t, output)
 				assert.Contains(t, string(output), "c1: This line must be logged")

--- a/component/collection.go
+++ b/component/collection.go
@@ -119,9 +119,10 @@ func (c *Collection) Any() *Component {
 	return nil
 }
 
-// All returns all components as a map.
+// All returns a shallow copy of all components as a map.
+// A copy is returned so the caller cannot mutate the internal state.
 func (c *Collection) All() map[string]*Component {
-	return c.components
+	return maps.Clone(c.components)
 }
 
 // AllOrdered returns all components sorted by name.

--- a/component/component.go
+++ b/component/component.go
@@ -11,18 +11,19 @@ import (
 
 // Component defines a main building block of FMesh.
 type Component struct {
-	name        string
-	description string
-	labels      *meta.Labels
-	scalars     *meta.Scalars
-	inputPorts  *port.Collection
-	outputPorts *port.Collection
-	f           ActivationFunc
-	logger      *log.Logger
-	state       State
-	parentMesh  ParentMesh
-	hooks       *Hooks
-	plugins     Plugins
+	name         string
+	description  string
+	labels       *meta.Labels
+	scalars      *meta.Scalars
+	inputPorts   *port.Collection
+	outputPorts  *port.Collection
+	f            ActivationFunc
+	logger       *log.Logger
+	customLogger bool // true when the logger was set explicitly and must not be inherited from the mesh
+	state        State
+	parentMesh   ParentMesh
+	hooks        *Hooks
+	plugins      Plugins
 }
 
 // New creates a new component with the given name and options.

--- a/component/io.go
+++ b/component/io.go
@@ -182,13 +182,12 @@ func (c *Component) InputByName(name string) *port.Port {
 
 // FlushOutputs pushes signals out of the component outputs to pipes and clears outputs.
 func (c *Component) FlushOutputs() error {
-	ports := c.Outputs().All()
-	for _, out := range ports {
+	return c.Outputs().ForEach(func(out *port.Port) error {
 		if err := out.Flush(); err != nil {
 			return fmt.Errorf("failed to flush output port %q: %w", out.Name(), err)
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // ClearInputs clears all input ports.

--- a/component/logging.go
+++ b/component/logging.go
@@ -16,13 +16,29 @@ func (c *Component) Logger() *log.Logger {
 	return c.logger
 }
 
-// WithLogger is a component constructor option that creates a new logger prefixed with component name.
+// WithLogger is a component constructor option that sets a custom logger.
+// A custom logger is never overridden by the mesh logger.
 func WithLogger(logger *log.Logger) Option {
 	return func(c *Component) error {
-		if logger == nil {
-			return errors.New("logger cannot be nil")
-		}
-		c.logger = logger
-		return nil
+		return c.SetLogger(logger)
 	}
+}
+
+// SetLogger sets a custom logger. A custom logger is never overridden by the mesh logger.
+func (c *Component) SetLogger(logger *log.Logger) error {
+	if logger == nil {
+		return errors.New("logger cannot be nil")
+	}
+	c.logger = logger
+	c.customLogger = true
+	return nil
+}
+
+// InheritLogger sets the given logger only when the component has no custom logger.
+// Called by the mesh when the component is added, so components share the mesh logger by default.
+func (c *Component) InheritLogger(logger *log.Logger) {
+	if c.customLogger || logger == nil {
+		return
+	}
+	c.logger = logger
 }

--- a/config.go
+++ b/config.go
@@ -17,7 +17,10 @@ type Config struct {
 	// 0 means no limit (use WithUnlimitedCycles to express this explicitly).
 	CyclesLimit int
 
-	// TimeLimit defines the maximum duration F-Mesh can run before being forcefully stopped.
+	// TimeLimit defines the maximum duration F-Mesh can run.
+	// The limit is checked between activation cycles: a cycle that is already
+	// running is never interrupted, so a long or blocking activation function
+	// can exceed the limit.
 	// 0 means no limit (use WithUnlimitedTime to express this explicitly).
 	TimeLimit time.Duration
 }

--- a/cycle/cycle.go
+++ b/cycle/cycle.go
@@ -71,8 +71,10 @@ func (c *Cycle) HasActivatedComponents() bool {
 }
 
 // AddActivationResults adds multiple activation results.
+// Safe for concurrent use: the underlying collection is mutex-protected and
+// the field is never reassigned.
 func (c *Cycle) AddActivationResults(activationResults ...*component.ActivationResult) *Cycle {
-	c.activationResults = c.ActivationResults().Add(activationResults...)
+	c.ActivationResults().Add(activationResults...)
 	return c
 }
 

--- a/cycle/cycle_test.go
+++ b/cycle/cycle_test.go
@@ -99,7 +99,7 @@ func TestCycle_HasErrors(t *testing.T) {
 			name: "some components returned errors",
 			cycleResult: New().AddActivationResults(
 				component.NewActivationResult("c1").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
-				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).WithActivationError(errors.New("some error")),
+				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).AddActivationError(errors.New("some error")),
 				component.NewActivationResult("c3").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
 			),
 			want: true,
@@ -127,7 +127,7 @@ func TestCycle_HasPanics(t *testing.T) {
 			name: "has activation results, but no one is panic",
 			cycleResult: New().AddActivationResults(
 				component.NewActivationResult("c1").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
-				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).WithActivationError(errors.New("some error")),
+				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).AddActivationError(errors.New("some error")),
 			),
 			want: false,
 		},
@@ -135,9 +135,9 @@ func TestCycle_HasPanics(t *testing.T) {
 			name: "some components panicked",
 			cycleResult: New().AddActivationResults(
 				component.NewActivationResult("c1").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
-				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).WithActivationError(errors.New("some error")),
+				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).AddActivationError(errors.New("some error")),
 				component.NewActivationResult("c3").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
-				component.NewActivationResult("c4").SetActivated(true).SetActivationCode(component.ActivationCodePanicked).WithActivationError(errors.New("some panic")),
+				component.NewActivationResult("c4").SetActivated(true).SetActivationCode(component.ActivationCodePanicked).AddActivationError(errors.New("some panic")),
 			),
 			want: true,
 		},
@@ -279,7 +279,7 @@ func TestCycle_AllErrorsCombined(t *testing.T) {
 		{
 			name: "single error",
 			cycle: New().AddActivationResults(
-				component.NewActivationResult("c1").WithActivationError(err1).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
+				component.NewActivationResult("c1").AddActivationError(err1).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
 			),
 			wantErr: true,
 			wantMsg: "error 1",
@@ -287,8 +287,8 @@ func TestCycle_AllErrorsCombined(t *testing.T) {
 		{
 			name: "multiple errors",
 			cycle: New().AddActivationResults(
-				component.NewActivationResult("c1").WithActivationError(err1).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
-				component.NewActivationResult("c2").WithActivationError(err2).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
+				component.NewActivationResult("c1").AddActivationError(err1).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
+				component.NewActivationResult("c2").AddActivationError(err2).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
 			),
 			wantErr: true,
 			wantMsg: "error 1",
@@ -325,7 +325,7 @@ func TestCycle_AllPanicsCombined(t *testing.T) {
 		{
 			name: "single panic",
 			cycle: New().AddActivationResults(
-				component.NewActivationResult("c1").WithActivationError(panic1).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
+				component.NewActivationResult("c1").AddActivationError(panic1).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
 			),
 			wantErr: true,
 			wantMsg: "panic 1",
@@ -333,8 +333,8 @@ func TestCycle_AllPanicsCombined(t *testing.T) {
 		{
 			name: "multiple panics",
 			cycle: New().AddActivationResults(
-				component.NewActivationResult("c1").WithActivationError(panic1).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
-				component.NewActivationResult("c2").WithActivationError(panic2).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
+				component.NewActivationResult("c1").AddActivationError(panic1).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
+				component.NewActivationResult("c2").AddActivationError(panic2).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
 			),
 			wantErr: true,
 			wantMsg: "panic 1",

--- a/cycle/group.go
+++ b/cycle/group.go
@@ -74,12 +74,7 @@ func (g *Group) RemoveScalarOnEach(names ...string) *Group {
 // because cycles represent historical execution records - users need to access
 // cycles that had errors to understand what happened.
 func (g *Group) Add(cycles ...*Cycle) *Group {
-	newCycles := make([]*Cycle, len(g.cycles)+len(cycles))
-	copy(newCycles, g.cycles)
-	for i, c := range cycles {
-		newCycles[len(g.cycles)+i] = c
-	}
-	g.cycles = newCycles
+	g.cycles = append(g.cycles, cycles...)
 	return g
 }
 
@@ -150,9 +145,10 @@ func (g *Group) First() *Cycle {
 	return g.cycles[0]
 }
 
-// All returns all cycles as a slice.
+// All returns a cloned slice of cycles. The slice is independent of the group;
+// the *Cycle pointers inside are shared.
 func (g *Group) All() []*Cycle {
-	return g.cycles
+	return slices.Clone(g.cycles)
 }
 
 // Every returns true if all cycles match the predicate.

--- a/fmesh.go
+++ b/fmesh.go
@@ -199,27 +199,28 @@ func (fm *FMesh) runCycle() error {
 
 	if err := fm.hooks.beforeCycle.Trigger(&CycleContext{FMesh: fm, Cycle: newCycle}); err != nil {
 		cycleErr := errors.Join(errFailedToRunCycle, fmt.Errorf("beforeCycle hook failed: %w", err))
-		fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(newCycle)
+		fm.runtimeInfo.Cycles.Add(newCycle)
 		return cycleErr
 	}
 
 	fm.LogDebug("starting activation cycle #%d", newCycle.Number())
 
-	components := fm.Components().All()
-	if len(components) == 0 {
-		fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(newCycle)
+	if fm.Components().IsEmpty() {
+		fm.runtimeInfo.Cycles.Add(newCycle)
 		return errors.Join(errFailedToRunCycle, errNoComponents)
 	}
 
 	var wg sync.WaitGroup
 
-	for _, c := range components {
+	// ForEach avoids cloning the component map on every cycle (hot path)
+	_ = fm.Components().ForEach(func(c *component.Component) error {
 		wg.Add(1)
 		go func(comp *component.Component, cyc *cycle.Cycle) {
 			defer wg.Done()
-			cyc.ActivationResults().Add(comp.MaybeActivate())
+			cyc.AddActivationResults(comp.MaybeActivate())
 		}(c, newCycle)
-	}
+		return nil
+	})
 
 	wg.Wait()
 
@@ -233,11 +234,11 @@ func (fm *FMesh) runCycle() error {
 
 	if err := fm.hooks.afterCycle.Trigger(&CycleContext{FMesh: fm, Cycle: newCycle}); err != nil {
 		cycleErr := errors.Join(errFailedToRunCycle, fmt.Errorf("afterCycle hook failed: %w", err))
-		fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(newCycle)
+		fm.runtimeInfo.Cycles.Add(newCycle)
 		return cycleErr
 	}
 
-	fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(newCycle)
+	fm.runtimeInfo.Cycles.Add(newCycle)
 	return nil
 }
 
@@ -272,7 +273,6 @@ func (fm *FMesh) drainComponents() error {
 	return nil
 }
 
-// @TODO: we can inline this into drainComponents
 // clearInputs clears all the input ports of all components activated in the latest cycle.
 func (fm *FMesh) clearInputs(components []*component.Component) error {
 	lastCycle := fm.runtimeInfo.Cycles.Last()

--- a/fmesh.go
+++ b/fmesh.go
@@ -170,6 +170,7 @@ func (fm *FMesh) AddComponents(components ...*component.Component) error {
 		}
 
 		c.SetParentMesh(fm)
+		c.InheritLogger(fm.logger)
 
 		if err := fm.components.Add(c); err != nil {
 			return fmt.Errorf("failed to add component %q to mesh: %w", c.Name(), err)

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -487,7 +487,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c1").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeReturnedError).
-							WithActivationError(errors.New("component returned an error: boom")),
+							AddActivationError(errors.New("component returned an error: boom")),
 					),
 			),
 			wantErr: true,
@@ -522,7 +522,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c1").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeWaitingForInputsClear).
-							WithActivationError(component.ErrWaitingForInputs),
+							AddActivationError(component.ErrWaitingForInputs),
 					),
 				// Mesh stops naturally in the next cycle because nothing is activated
 				cycle.New().
@@ -600,7 +600,7 @@ func TestFMesh_Run(t *testing.T) {
 				),
 				cycle.New().AddActivationResults(
 					component.NewActivationResult("c1").SetActivated(true).SetActivationCode(component.ActivationCodeOK),
-					component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeWaitingForInputsKeep).WithActivationError(component.ErrWaitingForInputsKeep),
+					component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeWaitingForInputsKeep).AddActivationError(component.ErrWaitingForInputsKeep),
 				),
 				cycle.New().AddActivationResults(
 					component.NewActivationResult("c1").SetActivated(true).SetActivationCode(component.ActivationCodeOK),
@@ -608,7 +608,7 @@ func TestFMesh_Run(t *testing.T) {
 				),
 				cycle.New().AddActivationResults(
 					component.NewActivationResult("c1").SetActivated(true).SetActivationCode(component.ActivationCodeOK),
-					component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeWaitingForInputsKeep).WithActivationError(component.ErrWaitingForInputsKeep),
+					component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeWaitingForInputsKeep).AddActivationError(component.ErrWaitingForInputsKeep),
 				),
 				cycle.New().AddActivationResults(
 					component.NewActivationResult("c1").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
@@ -681,7 +681,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c3").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeReturnedError).
-							WithActivationError(errors.New("component returned an error: boom")),
+							AddActivationError(errors.New("component returned an error: boom")),
 						component.NewActivationResult("c4").
 							SetActivated(false).
 							SetActivationCode(component.ActivationCodeNoInput),
@@ -715,7 +715,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c4").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodePanicked).
-							WithActivationError(errors.New("panicked with: no way")),
+							AddActivationError(errors.New("panicked with: no way")),
 					),
 			),
 			wantErr: true,
@@ -794,7 +794,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c3").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeReturnedError).
-							WithActivationError(errors.New("component returned an error: boom")),
+							AddActivationError(errors.New("component returned an error: boom")),
 						component.NewActivationResult("c4").
 							SetActivated(false).
 							SetActivationCode(component.ActivationCodeNoInput),
@@ -836,7 +836,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c4").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodePanicked).
-							WithActivationError(errors.New("panicked with: no way")),
+							AddActivationError(errors.New("panicked with: no way")),
 						component.NewActivationResult("c5").
 							SetActivated(false).
 							SetActivationCode(component.ActivationCodeNoInput),
@@ -1072,7 +1072,7 @@ func TestFMesh_mustStop(t *testing.T) {
 					component.NewActivationResult("c1").
 						SetActivated(true).
 						SetActivationCode(component.ActivationCodeReturnedError).
-						WithActivationError(errors.New("c1 activation finished with error")),
+						AddActivationError(errors.New("c1 activation finished with error")),
 				).SetNumber(5)
 				fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(c)
 				return fm
@@ -1090,7 +1090,7 @@ func TestFMesh_mustStop(t *testing.T) {
 					component.NewActivationResult("c1").
 						SetActivated(true).
 						SetActivationCode(component.ActivationCodePanicked).
-						WithActivationError(errors.New("c1 panicked")),
+						AddActivationError(errors.New("c1 panicked")),
 				).SetNumber(5)
 				fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(c)
 				return fm

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -1502,3 +1502,20 @@ func TestFMesh_Run_ValidatesOnEveryRun(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "wrong parent mesh")
 }
+
+func TestFMesh_AddComponents_LoggerInheritance(t *testing.T) {
+	meshLogger := log.New(io.Discard, "mesh: ", 0)
+	customLogger := log.New(io.Discard, "custom: ", 0)
+
+	fm := mustNewFMesh("logger-inheritance", WithLogger(meshLogger))
+
+	defaultLoggerComponent := mustNewComponent("plain", component.WithActivationFunc(noOpActivationFunc))
+	customLoggerComponent := mustNewComponent("custom",
+		component.WithActivationFunc(noOpActivationFunc),
+		component.WithLogger(customLogger))
+
+	require.NoError(t, fm.AddComponents(defaultLoggerComponent, customLoggerComponent))
+
+	assert.Same(t, meshLogger, defaultLoggerComponent.Logger(), "component without custom logger must inherit the mesh logger")
+	assert.Same(t, customLogger, customLoggerComponent.Logger(), "custom logger must not be overridden")
+}

--- a/hook/hook_group.go
+++ b/hook/hook_group.go
@@ -38,17 +38,6 @@ func (g *Group[T]) Trigger(arg T) error {
 	return nil
 }
 
-// ForEach applies an action to each hook function.
-// Note: Most users should use Trigger() instead.
-func (g *Group[T]) ForEach(action func(func(T) error) error) *Group[T] {
-	for _, hook := range g.hooks {
-		if err := action(hook); err != nil {
-			return g
-		}
-	}
-	return g
-}
-
 // Clear removes all hooks from the group.
 func (g *Group[T]) Clear() *Group[T] {
 	g.hooks = make([]func(T) error, 0)
@@ -56,7 +45,6 @@ func (g *Group[T]) Clear() *Group[T] {
 }
 
 // Len returns the number of hooks in the group.
-// Returns 0 if the group has a chainable error.
 func (g *Group[T]) Len() int {
 	return len(g.hooks)
 }

--- a/hook/hook_group_test.go
+++ b/hook/hook_group_test.go
@@ -144,23 +144,4 @@ func TestHookGroup_AdditionalMethods(t *testing.T) {
 		assert.Equal(t, 1, hg.Len())
 	})
 
-	t.Run("ForEach operates on hook functions", func(t *testing.T) {
-		count := 0
-		hg := NewGroup[int]()
-		hg.Add(func(i int) error {
-			return nil
-		}).Add(func(i int) error {
-			return nil
-		}).Add(func(i int) error {
-			return nil
-		})
-
-		result := hg.ForEach(func(hook func(int) error) error {
-			count++
-			return nil
-		})
-
-		assert.Equal(t, hg, result) // Returns self
-		assert.Equal(t, 3, count)
-	})
 }

--- a/port/collection.go
+++ b/port/collection.go
@@ -2,6 +2,7 @@ package port
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/hovsep/fmesh/meta"
 	"github.com/hovsep/fmesh/signal"
@@ -180,7 +181,7 @@ func (c *Collection) PipeTo(destPorts ...*Port) error {
 	return nil
 }
 
-// Add adds ports to a collection and returns it. Overwrites on name conflict.
+// Add adds ports to the collection. Returns an error on name conflict.
 func (c *Collection) Add(ports ...*Port) error {
 	for _, p := range ports {
 		if _, exists := c.ports[p.Name()]; exists {
@@ -209,9 +210,10 @@ func (c *Collection) Signals() *signal.Group {
 	return group
 }
 
-// All returns all ports as a map.
+// All returns a shallow copy of all ports as a map.
+// A copy is returned so the caller cannot mutate the internal state.
 func (c *Collection) All() map[string]*Port {
-	return c.ports
+	return maps.Clone(c.ports)
 }
 
 // Any returns any arbitrary port from the collection.

--- a/port/group.go
+++ b/port/group.go
@@ -161,9 +161,10 @@ func (g *Group) setPorts(ports []*Port) *Group {
 	return g
 }
 
-// All returns all ports as a slice.
+// All returns a cloned slice of ports. The slice is independent of the group;
+// the *Port pointers inside are shared.
 func (g *Group) All() []*Port {
-	return g.ports
+	return slices.Clone(g.ports)
 }
 
 // Len returns the number of ports in a group.

--- a/port/hooks.go
+++ b/port/hooks.go
@@ -30,6 +30,9 @@ type OutboundPipeContext struct {
 }
 
 // Hooks is a registry of all hook types for Port.
+// Port hooks may fire from concurrent activation goroutines (components call
+// PutSignals on their own ports while activating), so hook functions must be
+// safe for concurrent use when they touch shared state.
 type Hooks struct {
 	onSignalsAdded *hook.Group[*SignalsAddedContext]
 	onClear        *hook.Group[*ClearContext]

--- a/port/port.go
+++ b/port/port.go
@@ -1,6 +1,7 @@
 package port
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hovsep/fmesh/meta"
@@ -207,30 +208,28 @@ func (p *Port) Signals() *signal.Group {
 }
 
 // PutSignals adds signals to the port.
+// When the OnSignalsAdded hook fails, the port is restored to its previous state.
 func (p *Port) PutSignals(signals ...*signal.Signal) error {
-	p.setSignals(p.Signals().With(signals...))
+	return p.putSignals(signals)
+}
 
-	// Trigger OnSignalsAdded hook
+// PutPayloads creates signals from given payloads.
+// When the OnSignalsAdded hook fails, the port is restored to its previous state.
+func (p *Port) PutPayloads(payloads ...any) error {
+	return p.putSignals(signal.NewGroup(payloads...).All())
+}
+
+// putSignals adds signals to the port and triggers the OnSignalsAdded hook,
+// rolling the port back when the hook fails.
+func (p *Port) putSignals(signals []*signal.Signal) error {
+	previousSignals := p.Signals()
+	p.setSignals(previousSignals.With(signals...))
+
 	if err := p.hooks.onSignalsAdded.Trigger(&SignalsAddedContext{
 		Port:         p,
 		SignalsAdded: signals,
 	}); err != nil {
-		return fmt.Errorf("onSignalsAdded hook failed: %w", err)
-	}
-
-	return nil
-}
-
-// PutPayloads creates signals from given payloads.
-func (p *Port) PutPayloads(payloads ...any) error {
-	newSignals := signal.NewGroup(payloads...).All()
-	p.setSignals(p.Signals().With(newSignals...))
-
-	// Trigger OnSignalsAdded hook
-	if err := p.hooks.onSignalsAdded.Trigger(&SignalsAddedContext{
-		Port:         p,
-		SignalsAdded: newSignals,
-	}); err != nil {
+		p.setSignals(previousSignals)
 		return fmt.Errorf("onSignalsAdded hook failed: %w", err)
 	}
 
@@ -265,6 +264,12 @@ func (p *Port) Clear() error {
 }
 
 // Flush pushes signals to pipes and clears the port (output ports only).
+// Fan-out forwards the same *Signal pointers to every destination — payloads
+// must be treated as immutable by all receivers.
+// Delivery to every pipe is attempted even when some fail; the errors are
+// joined and the port is cleared only when all deliveries succeeded, so
+// successfully delivered signals are never lost, but a retry after a partial
+// failure re-delivers to the destinations that already received them.
 func (p *Port) Flush() error {
 	if p.IsInput() {
 		return fmt.Errorf("cannot flush input port %q: only output ports can be flushed", p.Name())
@@ -274,12 +279,17 @@ func (p *Port) Flush() error {
 		return nil
 	}
 
-	pipes := p.pipes.All()
-	for _, outboundPort := range pipes {
+	var deliveryErrs error
+	// ForEach avoids cloning the pipe slice on every flush (hot path)
+	_ = p.pipes.ForEach(func(outboundPort *Port) error {
 		// Fan-Out
 		if err := ForwardSignals(p, outboundPort); err != nil {
-			return err
+			deliveryErrs = errors.Join(deliveryErrs, err)
 		}
+		return nil
+	})
+	if deliveryErrs != nil {
+		return deliveryErrs
 	}
 	return p.Clear()
 }
@@ -295,6 +305,8 @@ func (p *Port) HasPipes() bool {
 }
 
 // PipeTo connects this port to destination ports.
+// Flushing fans out the same *Signal pointers to every destination, so
+// payloads must be treated as immutable by all receiving components.
 func (p *Port) PipeTo(destPorts ...*Port) error {
 	for _, destPort := range destPorts {
 		if err := validatePipe(p, destPort); err != nil {
@@ -335,6 +347,8 @@ func validatePipe(srcPort, dstPort *Port) error {
 }
 
 // ForwardSignals copies all signals from source to destination port without clearing source.
+// The same *Signal pointers are shared with the destination; payloads must be
+// treated as immutable because downstream components activate concurrently.
 func ForwardSignals(source, dest *Port) error {
 	signals := source.Signals().All()
 	return dest.PutSignals(signals...)
@@ -365,12 +379,4 @@ func (p *Port) setParentComponent(parentComponent ParentComponent) {
 func (p *Port) SetupHooks(configure func(*Hooks)) *Port {
 	configure(p.hooks)
 	return p
-}
-
-// ValidateBeforeActivation checks if the port is valid before parent component activation.
-func (p *Port) ValidateBeforeActivation() error {
-	if p.ParentComponent() == nil {
-		return fmt.Errorf("port %q has no parent component", p.name)
-	}
-	return nil
 }

--- a/signal/errors.go
+++ b/signal/errors.go
@@ -7,4 +7,8 @@ var (
 	ErrNoSignalsInGroup = errors.New("group has no signals")
 	// ErrPayloadNotComparable is returned when a payload type is not comparable.
 	ErrPayloadNotComparable = errors.New("payload type is not comparable, use ContainsPayloadFunc instead")
+	// ErrNoPayload is returned when a signal carries no payload (zero-value Signal).
+	ErrNoPayload = errors.New("signal has no payload")
+	// ErrScalarNotFoundInGroup is returned when no signal in the group has the requested scalar.
+	ErrScalarNotFoundInGroup = errors.New("no signal in the group has the scalar")
 )

--- a/signal/group.go
+++ b/signal/group.go
@@ -1,7 +1,6 @@
 package signal
 
 import (
-	"errors"
 	"reflect"
 	"slices"
 
@@ -300,23 +299,28 @@ func (g *Group) Filter(p Predicate) *Group {
 }
 
 // Map returns a new group with every signal transformed by the mapper.
+// Nil mapper results are dropped.
 func (g *Group) Map(m Mapper) *Group {
 	mapped := make([]*Signal, 0, len(g.signals))
 	for _, s := range g.signals {
-		mapped = append(mapped, m(cloneSignal(s)))
+		if result := m(cloneSignal(s)); result != nil {
+			mapped = append(mapped, result)
+		}
 	}
 	return newGroupFromSignals(mapped)
 }
 
 // MapIf is like Map but applies the mapper only to signals matching the predicate.
+// Nil mapper results are dropped.
 func (g *Group) MapIf(predicate Predicate, mapper Mapper) *Group {
-	mapped := make([]*Signal, len(g.signals))
-	for i, s := range g.signals {
+	mapped := make([]*Signal, 0, len(g.signals))
+	for _, s := range g.signals {
 		cloned := cloneSignal(s)
 		if predicate(s) {
-			mapped[i] = mapper(cloned)
-		} else {
-			mapped[i] = cloned
+			cloned = mapper(cloned)
+		}
+		if cloned != nil {
+			mapped = append(mapped, cloned)
 		}
 	}
 	return newGroupFromSignals(mapped)
@@ -369,62 +373,60 @@ func (g *Group) ReducePayloads(initial any, fn PayloadReducer) any {
 // SumScalar returns the sum of the named scalar across all signals in the group.
 // Signals that do not have the scalar contribute 0. Returns 0 for an empty group.
 func (g *Group) SumScalar(name string) float64 {
-	return g.Reduce(New(0.0), func(acc *Signal, s *Signal) *Signal {
-		return New(acc.PayloadOrDefault(0.0).(float64) + s.Scalars().ValueOrDefault(name, 0.0))
-	}).PayloadOrDefault(0.0).(float64)
+	sum := 0.0
+	for _, s := range g.signals {
+		sum += s.scalars.ValueOrDefault(name, 0.0)
+	}
+	return sum
 }
 
 // MinScalar returns the minimum value of the named scalar across all signals.
+// Returns ErrScalarNotFoundInGroup when no signal has the scalar.
 func (g *Group) MinScalar(name string) (float64, error) {
-	signalsWithScalar := g.Filter(func(signal *Signal) bool {
-		return signal.scalars.Has(name)
-	})
-
-	if signalsWithScalar.IsEmpty() {
-		return 0, errors.New("no signal in group has scalar")
-	}
-
-	minValue := signalsWithScalar.Reduce(signalsWithScalar.First(), func(acc *Signal, s *Signal) *Signal {
-		if s.Scalars().ValueOrDefault(name, 0.0) < acc.Scalars().ValueOrDefault(name, 0.0) {
-			return s
-		}
-		return acc
-	}).Scalars().ValueOrDefault(name, 0.0)
-
-	return minValue, nil
+	minValue, _, err := g.scalarStats(name)
+	return minValue, err
 }
 
 // MaxScalar returns the maximum value of the named scalar across all signals.
+// Returns ErrScalarNotFoundInGroup when no signal has the scalar.
 func (g *Group) MaxScalar(name string) (float64, error) {
-	signalsWithScalar := g.Filter(func(signal *Signal) bool {
-		return signal.scalars.Has(name)
-	})
-
-	if signalsWithScalar.IsEmpty() {
-		return 0, errors.New("no signal in group has scalar")
-	}
-
-	maxValue := signalsWithScalar.Reduce(signalsWithScalar.First(), func(acc *Signal, s *Signal) *Signal {
-		if s.Scalars().ValueOrDefault(name, 0.0) > acc.Scalars().ValueOrDefault(name, 0.0) {
-			return s
-		}
-		return acc
-	}).Scalars().ValueOrDefault(name, 0.0)
-
-	return maxValue, nil
+	_, maxValue, err := g.scalarStats(name)
+	return maxValue, err
 }
 
 // AvgScalar returns the mean value of the named scalar across all signals that have it.
+// Returns ErrScalarNotFoundInGroup when no signal has the scalar.
 func (g *Group) AvgScalar(name string) (float64, error) {
-	signalsWithScalar := g.Filter(func(signal *Signal) bool {
-		return signal.scalars.Has(name)
-	})
-
-	if signalsWithScalar.IsEmpty() {
-		return 0, errors.New("no signal in the group has the scalar")
+	sum, count := 0.0, 0
+	for _, s := range g.signals {
+		if s.scalars.Has(name) {
+			sum += s.scalars.ValueOrDefault(name, 0.0)
+			count++
+		}
 	}
-	sum := signalsWithScalar.Reduce(New(0.0), func(acc *Signal, s *Signal) *Signal {
-		return New(acc.PayloadOrDefault(0.0).(float64) + s.Scalars().ValueOrDefault(name, 0.0))
-	}).PayloadOrDefault(0.0).(float64)
-	return sum / float64(signalsWithScalar.Len()), nil
+	if count == 0 {
+		return 0, ErrScalarNotFoundInGroup
+	}
+	return sum / float64(count), nil
+}
+
+// scalarStats returns the min and max of the named scalar across signals that have it.
+func (g *Group) scalarStats(name string) (minValue, maxValue float64, err error) {
+	found := false
+	for _, s := range g.signals {
+		if !s.scalars.Has(name) {
+			continue
+		}
+		value := s.scalars.ValueOrDefault(name, 0.0)
+		if !found {
+			minValue, maxValue, found = value, value, true
+			continue
+		}
+		minValue = min(minValue, value)
+		maxValue = max(maxValue, value)
+	}
+	if !found {
+		return 0, 0, ErrScalarNotFoundInGroup
+	}
+	return minValue, maxValue, nil
 }

--- a/signal/group_test.go
+++ b/signal/group_test.go
@@ -952,3 +952,35 @@ func TestGroup_NilPayloadInvariant(t *testing.T) {
 		assert.False(t, found2)
 	})
 }
+
+func TestGroup_MapDropsNilResults(t *testing.T) {
+	dropOdd := func(s *Signal) *Signal {
+		if s.PayloadOrDefault(0).(int)%2 != 0 {
+			return nil
+		}
+		return s
+	}
+
+	t.Run("Map drops nil mapper results", func(t *testing.T) {
+		g := NewGroup(1, 2, 3, 4).Map(dropOdd)
+		assert.Equal(t, 2, g.Len())
+		require.NoError(t, g.ForEach(func(s *Signal) error {
+			_, err := s.Payload()
+			return err
+		}))
+	})
+
+	t.Run("MapIf drops nil mapper results and keeps non-matching signals", func(t *testing.T) {
+		isOdd := func(s *Signal) bool {
+			return s.PayloadOrDefault(0).(int)%2 != 0
+		}
+		g := NewGroup(1, 2, 3, 4).MapIf(isOdd, func(*Signal) *Signal {
+			return nil
+		})
+		assert.Equal(t, 2, g.Len())
+
+		payloads, err := g.AllPayloads()
+		require.NoError(t, err)
+		assert.Equal(t, []any{2, 4}, payloads)
+	})
+}

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -144,8 +144,13 @@ func (s *Signal) MapPayload(mapper PayloadMapper) *Signal {
 }
 
 // Payload returns the signal's payload. The value is shallow: if the payload is
-// a pointer, slice, or map, the caller must not mutate it.
+// a pointer, slice, or map, the caller must not mutate it — after fan-out the
+// same payload may be shared by components activating concurrently.
+// Returns ErrNoPayload for a zero-value Signal (use New to create signals).
 func (s *Signal) Payload() (any, error) {
+	if len(s.payload) == 0 {
+		return nil, ErrNoPayload
+	}
 	return s.payload[0], nil
 }
 

--- a/signal/signal_test.go
+++ b/signal/signal_test.go
@@ -533,3 +533,12 @@ func TestSignal_NilPayloadInvariant(t *testing.T) {
 		})
 	}
 }
+
+func TestSignal_ZeroValueHasNoPayload(t *testing.T) {
+	var s Signal
+
+	_, err := s.Payload()
+	require.ErrorIs(t, err, ErrNoPayload)
+	assert.Nil(t, s.PayloadOrNil())
+	assert.Equal(t, "fallback", s.PayloadOrDefault("fallback"))
+}


### PR DESCRIPTION
…sentinels

- Group.Map/MapIf drop nil mapper results instead of admitting nil signals that panic later (matches port.Group/cycle.Group semantics)
- Signal.Payload returns ErrNoPayload for a zero-value Signal instead of panicking; document payload immutability under fan-out
- Min/Max/AvgScalar return the ErrScalarNotFoundInGroup sentinel; Sum/Avg rewritten as plain loops (no per-element Signal allocation)