### PR TITLE
Cleanups and minor fixes across the core packages

### DIFF
--- a/component/activation.go
+++ b/component/activation.go
@@ -3,6 +3,7 @@ package component
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/hovsep/fmesh/hook"
 )
@@ -34,7 +35,7 @@ func (c *Component) activate() (result *ActivationResult) {
 
 	defer func() {
 		if r := recover(); r != nil {
-			result = c.newActivationResultPanicked(fmt.Errorf("panicked with: %v", r))
+			result = c.newActivationResultPanicked(fmt.Errorf("panicked with: %v, stack: %s", r, debug.Stack()))
 			c.triggerHooksForResult(result, c.hooks.onPanic)
 			c.triggerAfterActivation(result)
 		}
@@ -92,7 +93,7 @@ func (c *Component) buildResultAndTriggerHook(err error) *ActivationResult {
 func (c *Component) triggerHooksForResult(result *ActivationResult, hookGroup *hook.Group[*ActivationContext]) {
 	if err := hookGroup.Trigger(&ActivationContext{Component: c, Result: result}); err != nil {
 		result.SetActivationCode(ActivationCodeHookFailed).
-			WithActivationError(fmt.Errorf("activation hook failed: %w", err))
+			AddActivationError(fmt.Errorf("activation hook failed: %w", err))
 	}
 }
 
@@ -100,6 +101,6 @@ func (c *Component) triggerHooksForResult(result *ActivationResult, hookGroup *h
 func (c *Component) triggerAfterActivation(result *ActivationResult) {
 	if err := c.hooks.afterActivation.Trigger(&ActivationContext{Component: c, Result: result}); err != nil {
 		result.SetActivationCode(ActivationCodeHookFailed).
-			WithActivationError(fmt.Errorf("afterActivation hook failed: %w", err))
+			AddActivationError(fmt.Errorf("afterActivation hook failed: %w", err))
 	}
 }

--- a/component/activation_result.go
+++ b/component/activation_result.go
@@ -125,8 +125,8 @@ func (ar *ActivationResult) SetActivationCode(code ActivationResultCode) *Activa
 	return ar
 }
 
-// WithActivationError appends an error to the activation result's error list and returns the activation result.
-func (ar *ActivationResult) WithActivationError(activationError error) *ActivationResult {
+// AddActivationError appends an error to the activation result's error list and returns the activation result.
+func (ar *ActivationResult) AddActivationError(activationError error) *ActivationResult {
 	ar.activationErrors = append(ar.activationErrors, activationError)
 	return ar
 }
@@ -147,14 +147,14 @@ func (c *Component) newActivationResultReturnedError(err error) *ActivationResul
 	return NewActivationResult(c.Name()).
 		SetActivated(true).
 		SetActivationCode(ActivationCodeReturnedError).
-		WithActivationError(fmt.Errorf("component returned an error: %w", err))
+		AddActivationError(fmt.Errorf("component returned an error: %w", err))
 }
 
 func (c *Component) newActivationResultPanicked(err error) *ActivationResult {
 	return NewActivationResult(c.Name()).
 		SetActivated(true).
 		SetActivationCode(ActivationCodePanicked).
-		WithActivationError(err)
+		AddActivationError(err)
 }
 
 // newActivationResultHookFailed builds a specific activation result for when a hook fails.
@@ -162,7 +162,7 @@ func (c *Component) newActivationResultHookFailed(err error) *ActivationResult {
 	return NewActivationResult(c.Name()).
 		SetActivated(false).
 		SetActivationCode(ActivationCodeHookFailed).
-		WithActivationError(err)
+		AddActivationError(err)
 }
 
 func (c *Component) newActivationResultWaitingForInputs(err error) *ActivationResult {
@@ -173,7 +173,7 @@ func (c *Component) newActivationResultWaitingForInputs(err error) *ActivationRe
 	return NewActivationResult(c.Name()).
 		SetActivated(true).
 		SetActivationCode(activationCode).
-		WithActivationError(err)
+		AddActivationError(err)
 }
 
 // IsWaitingForInput returns true if the component was waiting for inputs.

--- a/component/activation_result_collection_test.go
+++ b/component/activation_result_collection_test.go
@@ -272,7 +272,7 @@ func TestActivationResultCollection_Without(t *testing.T) {
 
 func TestActivationResult_ActivationErrorWithComponentName(t *testing.T) {
 	err := errors.New("activation failed")
-	r := NewActivationResult("my-component").WithActivationError(err)
+	r := NewActivationResult("my-component").AddActivationError(err)
 
 	t.Run("returns error with component name", func(t *testing.T) {
 		wrappedErr := r.ActivationErrorWithComponentName()
@@ -398,7 +398,7 @@ func TestActivationResult_WithActivationError_Accumulates(t *testing.T) {
 	err3 := errors.New("third error")
 
 	t.Run("single error", func(t *testing.T) {
-		r := NewActivationResult("c").WithActivationError(err1)
+		r := NewActivationResult("c").AddActivationError(err1)
 		assert.Len(t, r.ActivationErrors(), 1)
 		require.Error(t, r.ActivationError())
 		assert.ErrorIs(t, r.ActivationError(), err1)
@@ -406,9 +406,9 @@ func TestActivationResult_WithActivationError_Accumulates(t *testing.T) {
 
 	t.Run("multiple errors accumulate", func(t *testing.T) {
 		r := NewActivationResult("c").
-			WithActivationError(err1).
-			WithActivationError(err2).
-			WithActivationError(err3)
+			AddActivationError(err1).
+			AddActivationError(err2).
+			AddActivationError(err3)
 		assert.Len(t, r.ActivationErrors(), 3)
 		require.ErrorIs(t, r.ActivationError(), err1)
 		require.ErrorIs(t, r.ActivationError(), err2)

--- a/component/activation_test.go
+++ b/component/activation_test.go
@@ -81,7 +81,7 @@ func TestComponent_MaybeActivate(t *testing.T) {
 			wantActivationResult: NewActivationResult("c1").
 				SetActivated(true).
 				SetActivationCode(ActivationCodeReturnedError).
-				WithActivationError(errors.New("component returned an error: test error")),
+				AddActivationError(errors.New("component returned an error: test error")),
 		},
 		{
 			name: "activated without error",
@@ -118,7 +118,7 @@ func TestComponent_MaybeActivate(t *testing.T) {
 			wantActivationResult: NewActivationResult("c1").
 				SetActivated(true).
 				SetActivationCode(ActivationCodePanicked).
-				WithActivationError(errors.New("panicked with: oh shrimps")),
+				AddActivationError(errors.New("panicked with: oh shrimps")),
 		},
 		{
 			name: "component panicked with string",
@@ -137,7 +137,7 @@ func TestComponent_MaybeActivate(t *testing.T) {
 			wantActivationResult: NewActivationResult("c1").
 				SetActivated(true).
 				SetActivationCode(ActivationCodePanicked).
-				WithActivationError(errors.New("panicked with: oh shrimps")),
+				AddActivationError(errors.New("panicked with: oh shrimps")),
 		},
 		{
 			name: "component is waiting for inputs",
@@ -225,7 +225,7 @@ func TestComponent_MaybeActivate(t *testing.T) {
 			wantActivationResult: NewActivationResult("c1").
 				SetActivated(true).
 				SetActivationCode(ActivationCodeReturnedError).
-				WithActivationError(errors.New("component returned an error: test error")),
+				AddActivationError(errors.New("component returned an error: test error")),
 			loggerAssertions: func(t *testing.T, output []byte) {
 				assert.NotEmpty(t, output)
 				assert.Contains(t, string(output), "c1: This line must be logged")

--- a/component/collection.go
+++ b/component/collection.go
@@ -119,9 +119,10 @@ func (c *Collection) Any() *Component {
 	return nil
 }
 
-// All returns all components as a map.
+// All returns a shallow copy of all components as a map.
+// A copy is returned so the caller cannot mutate the internal state.
 func (c *Collection) All() map[string]*Component {
-	return c.components
+	return maps.Clone(c.components)
 }
 
 // AllOrdered returns all components sorted by name.

--- a/component/io.go
+++ b/component/io.go
@@ -182,13 +182,12 @@ func (c *Component) InputByName(name string) *port.Port {
 
 // FlushOutputs pushes signals out of the component outputs to pipes and clears outputs.
 func (c *Component) FlushOutputs() error {
-	ports := c.Outputs().All()
-	for _, out := range ports {
+	return c.Outputs().ForEach(func(out *port.Port) error {
 		if err := out.Flush(); err != nil {
 			return fmt.Errorf("failed to flush output port %q: %w", out.Name(), err)
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // ClearInputs clears all input ports.

--- a/config.go
+++ b/config.go
@@ -17,7 +17,10 @@ type Config struct {
 	// 0 means no limit (use WithUnlimitedCycles to express this explicitly).
 	CyclesLimit int
 
-	// TimeLimit defines the maximum duration F-Mesh can run before being forcefully stopped.
+	// TimeLimit defines the maximum duration F-Mesh can run.
+	// The limit is checked between activation cycles: a cycle that is already
+	// running is never interrupted, so a long or blocking activation function
+	// can exceed the limit.
 	// 0 means no limit (use WithUnlimitedTime to express this explicitly).
 	TimeLimit time.Duration
 }

--- a/cycle/cycle.go
+++ b/cycle/cycle.go
@@ -71,8 +71,10 @@ func (c *Cycle) HasActivatedComponents() bool {
 }
 
 // AddActivationResults adds multiple activation results.
+// Safe for concurrent use: the underlying collection is mutex-protected and
+// the field is never reassigned.
 func (c *Cycle) AddActivationResults(activationResults ...*component.ActivationResult) *Cycle {
-	c.activationResults = c.ActivationResults().Add(activationResults...)
+	c.ActivationResults().Add(activationResults...)
 	return c
 }
 

--- a/cycle/cycle_test.go
+++ b/cycle/cycle_test.go
@@ -99,7 +99,7 @@ func TestCycle_HasErrors(t *testing.T) {
 			name: "some components returned errors",
 			cycleResult: New().AddActivationResults(
 				component.NewActivationResult("c1").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
-				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).WithActivationError(errors.New("some error")),
+				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).AddActivationError(errors.New("some error")),
 				component.NewActivationResult("c3").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
 			),
 			want: true,
@@ -127,7 +127,7 @@ func TestCycle_HasPanics(t *testing.T) {
 			name: "has activation results, but no one is panic",
 			cycleResult: New().AddActivationResults(
 				component.NewActivationResult("c1").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
-				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).WithActivationError(errors.New("some error")),
+				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).AddActivationError(errors.New("some error")),
 			),
 			want: false,
 		},
@@ -135,9 +135,9 @@ func TestCycle_HasPanics(t *testing.T) {
 			name: "some components panicked",
 			cycleResult: New().AddActivationResults(
 				component.NewActivationResult("c1").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
-				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).WithActivationError(errors.New("some error")),
+				component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError).AddActivationError(errors.New("some error")),
 				component.NewActivationResult("c3").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
-				component.NewActivationResult("c4").SetActivated(true).SetActivationCode(component.ActivationCodePanicked).WithActivationError(errors.New("some panic")),
+				component.NewActivationResult("c4").SetActivated(true).SetActivationCode(component.ActivationCodePanicked).AddActivationError(errors.New("some panic")),
 			),
 			want: true,
 		},
@@ -279,7 +279,7 @@ func TestCycle_AllErrorsCombined(t *testing.T) {
 		{
 			name: "single error",
 			cycle: New().AddActivationResults(
-				component.NewActivationResult("c1").WithActivationError(err1).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
+				component.NewActivationResult("c1").AddActivationError(err1).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
 			),
 			wantErr: true,
 			wantMsg: "error 1",
@@ -287,8 +287,8 @@ func TestCycle_AllErrorsCombined(t *testing.T) {
 		{
 			name: "multiple errors",
 			cycle: New().AddActivationResults(
-				component.NewActivationResult("c1").WithActivationError(err1).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
-				component.NewActivationResult("c2").WithActivationError(err2).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
+				component.NewActivationResult("c1").AddActivationError(err1).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
+				component.NewActivationResult("c2").AddActivationError(err2).SetActivated(true).SetActivationCode(component.ActivationCodeReturnedError),
 			),
 			wantErr: true,
 			wantMsg: "error 1",
@@ -325,7 +325,7 @@ func TestCycle_AllPanicsCombined(t *testing.T) {
 		{
 			name: "single panic",
 			cycle: New().AddActivationResults(
-				component.NewActivationResult("c1").WithActivationError(panic1).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
+				component.NewActivationResult("c1").AddActivationError(panic1).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
 			),
 			wantErr: true,
 			wantMsg: "panic 1",
@@ -333,8 +333,8 @@ func TestCycle_AllPanicsCombined(t *testing.T) {
 		{
 			name: "multiple panics",
 			cycle: New().AddActivationResults(
-				component.NewActivationResult("c1").WithActivationError(panic1).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
-				component.NewActivationResult("c2").WithActivationError(panic2).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
+				component.NewActivationResult("c1").AddActivationError(panic1).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
+				component.NewActivationResult("c2").AddActivationError(panic2).SetActivated(true).SetActivationCode(component.ActivationCodePanicked),
 			),
 			wantErr: true,
 			wantMsg: "panic 1",

--- a/cycle/group.go
+++ b/cycle/group.go
@@ -74,12 +74,7 @@ func (g *Group) RemoveScalarOnEach(names ...string) *Group {
 // because cycles represent historical execution records - users need to access
 // cycles that had errors to understand what happened.
 func (g *Group) Add(cycles ...*Cycle) *Group {
-	newCycles := make([]*Cycle, len(g.cycles)+len(cycles))
-	copy(newCycles, g.cycles)
-	for i, c := range cycles {
-		newCycles[len(g.cycles)+i] = c
-	}
-	g.cycles = newCycles
+	g.cycles = append(g.cycles, cycles...)
 	return g
 }
 
@@ -150,9 +145,10 @@ func (g *Group) First() *Cycle {
 	return g.cycles[0]
 }
 
-// All returns all cycles as a slice.
+// All returns a cloned slice of cycles. The slice is independent of the group;
+// the *Cycle pointers inside are shared.
 func (g *Group) All() []*Cycle {
-	return g.cycles
+	return slices.Clone(g.cycles)
 }
 
 // Every returns true if all cycles match the predicate.

--- a/fmesh.go
+++ b/fmesh.go
@@ -199,27 +199,28 @@ func (fm *FMesh) runCycle() error {
 
 	if err := fm.hooks.beforeCycle.Trigger(&CycleContext{FMesh: fm, Cycle: newCycle}); err != nil {
 		cycleErr := errors.Join(errFailedToRunCycle, fmt.Errorf("beforeCycle hook failed: %w", err))
-		fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(newCycle)
+		fm.runtimeInfo.Cycles.Add(newCycle)
 		return cycleErr
 	}
 
 	fm.LogDebug("starting activation cycle #%d", newCycle.Number())
 
-	components := fm.Components().All()
-	if len(components) == 0 {
-		fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(newCycle)
+	if fm.Components().IsEmpty() {
+		fm.runtimeInfo.Cycles.Add(newCycle)
 		return errors.Join(errFailedToRunCycle, errNoComponents)
 	}
 
 	var wg sync.WaitGroup
 
-	for _, c := range components {
+	// ForEach avoids cloning the component map on every cycle (hot path)
+	_ = fm.Components().ForEach(func(c *component.Component) error {
 		wg.Add(1)
 		go func(comp *component.Component, cyc *cycle.Cycle) {
 			defer wg.Done()
-			cyc.ActivationResults().Add(comp.MaybeActivate())
+			cyc.AddActivationResults(comp.MaybeActivate())
 		}(c, newCycle)
-	}
+		return nil
+	})
 
 	wg.Wait()
 
@@ -233,11 +234,11 @@ func (fm *FMesh) runCycle() error {
 
 	if err := fm.hooks.afterCycle.Trigger(&CycleContext{FMesh: fm, Cycle: newCycle}); err != nil {
 		cycleErr := errors.Join(errFailedToRunCycle, fmt.Errorf("afterCycle hook failed: %w", err))
-		fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(newCycle)
+		fm.runtimeInfo.Cycles.Add(newCycle)
 		return cycleErr
 	}
 
-	fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(newCycle)
+	fm.runtimeInfo.Cycles.Add(newCycle)
 	return nil
 }
 
@@ -272,7 +273,6 @@ func (fm *FMesh) drainComponents() error {
 	return nil
 }
 
-// @TODO: we can inline this into drainComponents
 // clearInputs clears all the input ports of all components activated in the latest cycle.
 func (fm *FMesh) clearInputs(components []*component.Component) error {
 	lastCycle := fm.runtimeInfo.Cycles.Last()

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -487,7 +487,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c1").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeReturnedError).
-							WithActivationError(errors.New("component returned an error: boom")),
+							AddActivationError(errors.New("component returned an error: boom")),
 					),
 			),
 			wantErr: true,
@@ -522,7 +522,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c1").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeWaitingForInputsClear).
-							WithActivationError(component.ErrWaitingForInputs),
+							AddActivationError(component.ErrWaitingForInputs),
 					),
 				// Mesh stops naturally in the next cycle because nothing is activated
 				cycle.New().
@@ -600,7 +600,7 @@ func TestFMesh_Run(t *testing.T) {
 				),
 				cycle.New().AddActivationResults(
 					component.NewActivationResult("c1").SetActivated(true).SetActivationCode(component.ActivationCodeOK),
-					component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeWaitingForInputsKeep).WithActivationError(component.ErrWaitingForInputsKeep),
+					component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeWaitingForInputsKeep).AddActivationError(component.ErrWaitingForInputsKeep),
 				),
 				cycle.New().AddActivationResults(
 					component.NewActivationResult("c1").SetActivated(true).SetActivationCode(component.ActivationCodeOK),
@@ -608,7 +608,7 @@ func TestFMesh_Run(t *testing.T) {
 				),
 				cycle.New().AddActivationResults(
 					component.NewActivationResult("c1").SetActivated(true).SetActivationCode(component.ActivationCodeOK),
-					component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeWaitingForInputsKeep).WithActivationError(component.ErrWaitingForInputsKeep),
+					component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeWaitingForInputsKeep).AddActivationError(component.ErrWaitingForInputsKeep),
 				),
 				cycle.New().AddActivationResults(
 					component.NewActivationResult("c1").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
@@ -681,7 +681,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c3").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeReturnedError).
-							WithActivationError(errors.New("component returned an error: boom")),
+							AddActivationError(errors.New("component returned an error: boom")),
 						component.NewActivationResult("c4").
 							SetActivated(false).
 							SetActivationCode(component.ActivationCodeNoInput),
@@ -715,7 +715,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c4").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodePanicked).
-							WithActivationError(errors.New("panicked with: no way")),
+							AddActivationError(errors.New("panicked with: no way")),
 					),
 			),
 			wantErr: true,
@@ -794,7 +794,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c3").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeReturnedError).
-							WithActivationError(errors.New("component returned an error: boom")),
+							AddActivationError(errors.New("component returned an error: boom")),
 						component.NewActivationResult("c4").
 							SetActivated(false).
 							SetActivationCode(component.ActivationCodeNoInput),
@@ -836,7 +836,7 @@ func TestFMesh_Run(t *testing.T) {
 						component.NewActivationResult("c4").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodePanicked).
-							WithActivationError(errors.New("panicked with: no way")),
+							AddActivationError(errors.New("panicked with: no way")),
 						component.NewActivationResult("c5").
 							SetActivated(false).
 							SetActivationCode(component.ActivationCodeNoInput),
@@ -1072,7 +1072,7 @@ func TestFMesh_mustStop(t *testing.T) {
 					component.NewActivationResult("c1").
 						SetActivated(true).
 						SetActivationCode(component.ActivationCodeReturnedError).
-						WithActivationError(errors.New("c1 activation finished with error")),
+						AddActivationError(errors.New("c1 activation finished with error")),
 				).SetNumber(5)
 				fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(c)
 				return fm
@@ -1090,7 +1090,7 @@ func TestFMesh_mustStop(t *testing.T) {
 					component.NewActivationResult("c1").
 						SetActivated(true).
 						SetActivationCode(component.ActivationCodePanicked).
-						WithActivationError(errors.New("c1 panicked")),
+						AddActivationError(errors.New("c1 panicked")),
 				).SetNumber(5)
 				fm.runtimeInfo.Cycles = fm.runtimeInfo.Cycles.Add(c)
 				return fm

--- a/hook/hook_group.go
+++ b/hook/hook_group.go
@@ -38,17 +38,6 @@ func (g *Group[T]) Trigger(arg T) error {
 	return nil
 }
 
-// ForEach applies an action to each hook function.
-// Note: Most users should use Trigger() instead.
-func (g *Group[T]) ForEach(action func(func(T) error) error) *Group[T] {
-	for _, hook := range g.hooks {
-		if err := action(hook); err != nil {
-			return g
-		}
-	}
-	return g
-}
-
 // Clear removes all hooks from the group.
 func (g *Group[T]) Clear() *Group[T] {
 	g.hooks = make([]func(T) error, 0)
@@ -56,7 +45,6 @@ func (g *Group[T]) Clear() *Group[T] {
 }
 
 // Len returns the number of hooks in the group.
-// Returns 0 if the group has a chainable error.
 func (g *Group[T]) Len() int {
 	return len(g.hooks)
 }

--- a/hook/hook_group_test.go
+++ b/hook/hook_group_test.go
@@ -144,23 +144,4 @@ func TestHookGroup_AdditionalMethods(t *testing.T) {
 		assert.Equal(t, 1, hg.Len())
 	})
 
-	t.Run("ForEach operates on hook functions", func(t *testing.T) {
-		count := 0
-		hg := NewGroup[int]()
-		hg.Add(func(i int) error {
-			return nil
-		}).Add(func(i int) error {
-			return nil
-		}).Add(func(i int) error {
-			return nil
-		})
-
-		result := hg.ForEach(func(hook func(int) error) error {
-			count++
-			return nil
-		})
-
-		assert.Equal(t, hg, result) // Returns self
-		assert.Equal(t, 3, count)
-	})
 }

--- a/port/collection.go
+++ b/port/collection.go
@@ -2,6 +2,7 @@ package port
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/hovsep/fmesh/meta"
 	"github.com/hovsep/fmesh/signal"
@@ -180,7 +181,7 @@ func (c *Collection) PipeTo(destPorts ...*Port) error {
 	return nil
 }
 
-// Add adds ports to a collection and returns it. Overwrites on name conflict.
+// Add adds ports to the collection. Returns an error on name conflict.
 func (c *Collection) Add(ports ...*Port) error {
 	for _, p := range ports {
 		if _, exists := c.ports[p.Name()]; exists {
@@ -209,9 +210,10 @@ func (c *Collection) Signals() *signal.Group {
 	return group
 }
 
-// All returns all ports as a map.
+// All returns a shallow copy of all ports as a map.
+// A copy is returned so the caller cannot mutate the internal state.
 func (c *Collection) All() map[string]*Port {
-	return c.ports
+	return maps.Clone(c.ports)
 }
 
 // Any returns any arbitrary port from the collection.

--- a/port/group.go
+++ b/port/group.go
@@ -161,9 +161,10 @@ func (g *Group) setPorts(ports []*Port) *Group {
 	return g
 }
 
-// All returns all ports as a slice.
+// All returns a cloned slice of ports. The slice is independent of the group;
+// the *Port pointers inside are shared.
 func (g *Group) All() []*Port {
-	return g.ports
+	return slices.Clone(g.ports)
 }
 
 // Len returns the number of ports in a group.


### PR DESCRIPTION
- Rename mutating WithActivationError to AddActivationError (naming rule)
- All() returns defensive copies on component/port collections and port/cycle groups; internal hot paths use non-cloning ForEach
- Fix latent race: Cycle.AddActivationResults no longer reassigns the collection field; scheduler uses it directly
- Simplify cycle.Group.Add (drop pointless full-slice copy per cycle)
- Include stack trace in recovered activation panics
- Remove dead exports (hook.Group.ForEach) and stale comments; honest TimeLimit doc (checked between cycles, cycles are not interrupted)