### PR TITLE
Docs pass, compiling README example, benchmarks

### DIFF
--- a/.agent/docs/design.md
+++ b/.agent/docs/design.md
@@ -25,7 +25,7 @@
 
 **Fan-out shares pointers.** Output→input fan-out forwards the same `*Signal` pointers to all destinations. Do not add deep-copy to `ForwardSignals` or `Flush`.
 
-**No generics.** `signal`/`meta` use `any`/`float64`; FBP requires mixed-type signal flows in one group.
+**No generics in data flow.** `signal`/`meta` use `any`/`float64`; FBP requires mixed-type signal flows in one group. Approved generics elsewhere: `hook.Group[T]` (typed hook registry) and `component.MustGetTyped[T]` (state accessor). Do not add more without approval.
 
 **Minimise `reflect`.** Only when no alternative exists. Current approved use: `reflect.TypeOf(payload).Comparable()` in `ContainsPayload` — always nil-guard before calling `.Comparable()`.
 
@@ -34,20 +34,21 @@
 - **`signal`** — `payload` is `[]any{value}` (single-element slice so `nil` is valid). Predicate combinators and label constructors live in `predicates.go`. `ForEach` returns `(*Group, error)`.
 - **`meta`** — `Labels` (string k/v) and `Scalars` (string→float64). `Keys()`/`Values()` return sorted slices for determinism. `Merge(other)` is the one non-mutating method on both types. `Every(pred)` on empty = `true` (vacuous truth). `ForEach` returns `error`. Constructors: `NewLabels()`, `NewScalars()`.
 - **`port`** — `Flush()` fans out then clears source. `PipeTo` is output→input only. Both return `error`. `PipeTo` validates direction at call time.
-- **`component`** — `State` is `map[string]any`, persistent across cycles. Constructors use functional options: `component.New(name, opts...) (*Component, error)`.
+- **`component`** — `State` is `map[string]any`, persistent across cycles and across `Run`s (see [runtime.md](runtime.md)). Constructors use functional options: `component.New(name, opts...) (*Component, error)`. Ports come in two creation styles: name-based (`WithInputs`/`AddInputs`, `WithIndexedInputs("i", 1, 3)` → `i1..i3`) and attach-based (`AttachInputPorts` for pre-built `port.NewInput` ports with options). `LoopbackPipe(out, in)` wires a component to itself (such a mesh never stops naturally). `ErrWaitingForInputs`/`ErrWaitingForInputsKeep` are scheduler control-flow sentinels, not failures.
+- **`hook`** — generic `hook.Group[T]`, ordered, fail-fast `Trigger`. Three hook levels (mesh/component/port); see [hooks.md](hooks.md).
 - **`cycle`** — has its own `Any`/`Every`/`Count` on its collection type, independent of `signal.Group`.
 
 ## Metadata tiers on groups/collections
 
-Every Group and Collection type carries its **own** `*meta.Labels` and `*meta.Scalars` (Tier 1), plus batch mutation of its **contents** (Tier 2a). `signal.Group` and `port.Group` additionally expose cross-entity scalar aggregation (Tier 2b).
+Every Group and Collection type carries its **own** `*meta.Labels` and `*meta.Scalars` (Tier 1), plus batch mutation of its **contents** (Tier 2a). `signal.Group` additionally exposes cross-entity scalar aggregation (Tier 2b).
 
 | Tier | Methods | Where |
 |---|---|---|
 | 1 — entity's own | `Labels()`, `Scalars()`, `WithLabel(k,v)`, `WithScalar(k,v)` | all groups/collections |
 | 2a — batch on contents | `WithLabelOnEach(k,v)`, `WithScalarOnEach(k,v)`, `RemoveLabelOnEach(names...)`, `RemoveScalarOnEach(names...)` | all groups/collections |
-| 2b — cross-entity aggregation | `MinScalar(name)`, `MaxScalar(name)`, `AvgScalar(name)`, `SumScalar(name)` | `signal.Group`, `port.Group` only |
+| 2b — cross-entity aggregation | `MinScalar(name)`, `MaxScalar(name)`, `AvgScalar(name)`, `SumScalar(name)` | `signal.Group` only |
 
-`signal.Group` batch methods (Tier 2a) preserve the group's own metadata on the returned group via `copyGroupMeta`. Cross-entity aggregation returns `(float64, bool)` where `bool` is false when no element has the named scalar; `SumScalar` always returns `float64` (0 when absent).
+`signal.Group` batch methods (Tier 2a) preserve the group's own metadata on the returned group via `copyGroupMeta`. `MinScalar`/`MaxScalar`/`AvgScalar` return `(float64, error)` with the sentinel `signal.ErrScalarNotFoundInGroup` when no element has the named scalar; `SumScalar` always returns `float64` (0 when absent).
 
 ## Comment hygiene
 

--- a/.agent/docs/hooks.md
+++ b/.agent/docs/hooks.md
@@ -1,0 +1,49 @@
+# Hooks & plugins — extension points
+
+Source: `hooks.go`, `component/hooks.go`, `port/hooks.go`, `hook/hook_group.go`, `component/plugin.go`.
+
+## The hook primitive
+
+`hook.Group[T]` (package `hook`) — the **one approved generic type** in the codebase. An ordered
+slice of `func(T) error`; `Trigger(arg)` runs all in insertion order, **fail-fast** on first error.
+Registration is chainable and happens through `SetupHooks(func(*Hooks))` closures (or the
+`WithHooks` constructor option on components) — the `Hooks` structs' fields are unexported, so
+closures are the only registration path.
+
+## Three hook levels
+
+| Level | Registration | Hooks | Context type |
+|---|---|---|---|
+| Mesh | `fm.SetupHooks(...)` | `OnComponentAdded`, `BeforeRun`, `AfterRun`, `BeforeCycle`, `AfterCycle` | `*FMesh` / `*CycleContext` / `*ComponentAddedContext` |
+| Component | `component.WithHooks(...)` option or `c.SetupHooks(...)` | `OnCreation`, `BeforeActivation`, `OnActivation`, `OnSuccess`, `OnError`, `OnPanic`, `OnWaitingForInputs`, `AfterActivation` | `*Component` / `*ActivationContext` |
+| Port | `port.Hooks` via port options | `OnSignalsAdded`, `OnClear`, `OnInboundPipe`, `OnOutboundPipe` | per-event context structs |
+
+## Semantics worth knowing
+
+- **`OnActivation` is special**: its hooks are `ActivationFunc`s appended after the main
+  activation function and run **sequentially in the same activation** — they share the error
+  path (first error aborts the chain and becomes the activation error).
+- **`AfterActivation` always runs** — success, error, panic, or waiting; a `finally` block.
+- Outcome hooks (`OnSuccess`/`OnError`/`OnPanic`/`OnWaitingForInputs`) fire before
+  `AfterActivation`. Distinguish waiting modes via `ctx.Result.Code()`
+  (`WaitingForInputsClear` vs `WaitingForInputsKeep`).
+- A **failing hook poisons the result**: the activation result is re-coded to
+  `ActivationCodeHookFailed` with the hook error attached. `HookFailed` results count as
+  activation errors (`IsError()`), so under `StopOnFirstErrorOrPanic` the mesh stops and the
+  hook error surfaces in `Run()`'s return. A failing `beforeCycle`/`afterCycle`
+  hook aborts the run (`errFailedToRunCycle`); a failing `onComponentAdded` hook fails
+  `AddComponents`.
+- The mesh's **default `BeforeRun` hook validates mesh structure** on every run (see
+  runtime.md). Don't clear the beforeRun group without re-adding equivalent validation.
+- Port hooks fire on every `PutSignals`/`PutPayloads`/`Clear`, including the scheduler's own
+  drain-phase forwarding and clearing — keep them cheap and side-effect-aware. They may fire
+  from concurrent activation goroutines, so they must be concurrency-safe when touching shared
+  state. When an `OnSignalsAdded` hook fails, the port rolls back to its previous signals.
+
+## Plugins
+
+`component.Plugin` interface: `GetName() string` + `Init(*Component) error`. Registered via the
+`component.WithPlugins(...)` constructor option; `Init` runs during `component.New` (after all
+other options), duplicate names are a construction error. Query with `c.PluginRegistered(name)`.
+A plugin is just an initialization bundle — typically registers hooks/ports on the component.
+Order inside `New`: options → plugin `Init`s → `OnCreation` hooks.

--- a/.agent/docs/naming.md
+++ b/.agent/docs/naming.md
@@ -19,10 +19,10 @@ Use `With` **only** when the method is one of:
 - **Builder that does real work beyond field assignment**: e.g. nil guard + prefix logic, iteration over child objects, appending to a slice
 
 Use `Set` for **everything else** that is a plain `field = value; return receiver` mutating method, whether exported or unexported:
-- Exported example: `cycle.SetNumber`, `component.SetLogger` (method needed post-construction for mesh logger inheritance)
+- Exported example: `cycle.SetNumber`, `component.SetLogger` (marks the logger as custom so the mesh never overrides it)
 - Unexported example: `port.setSignals`, `port.setPorts`
 
-**No dual-form duplication**: if a capability has a `With*` constructor option, do **not** also add a `Set*` method for the same capability. Keep one form: `With*` for options inside `New(...)`, `Set*` only when genuine post-construction mutation is needed (e.g. `SetLogger` called by `fmesh.AddComponents`).
+**No dual-form duplication**: if a capability has a `With*` constructor option, do **not** also add a `Set*` method for the same capability, unless genuine post-construction mutation is needed. Logger is the one exception: `component.WithLogger`/`component.SetLogger` mark the logger custom, and `component.InheritLogger` (called by `fmesh.AddComponents`) sets the mesh logger only on components without a custom one.
 
 ## Label operations by type
 
@@ -72,7 +72,9 @@ Constructor options use the `With` prefix and are passed to `New(...)`:
 | Initial state | `component.WithInitialState(fn)` |
 | Logger | `component.WithLogger(l)` |
 
-Post-construction `Set*` methods exist only where mutation is genuinely required after `New()` returns — currently `SetLogger` (called by `fmesh.AddComponents` to inherit the mesh logger) and `SetParentMesh`.
+Post-construction `Set*` methods exist only where mutation is genuinely required after `New()` returns — currently `SetLogger`, `SetParentMesh`, and `InheritLogger` (called by `fmesh.AddComponents`; sets the mesh logger unless a custom one was set).
+
+Mutating methods that *append* use `Add*` even on result types: `ActivationResult.AddActivationError` (appends to the error list).
 
 ## Collection/group operations
 

--- a/.agent/docs/runtime.md
+++ b/.agent/docs/runtime.md
@@ -1,0 +1,70 @@
+# Runtime — execution model
+
+How a mesh actually runs. Source: `fmesh.go` (`Run`, `runCycle`, `drainComponents`, `mustStop`),
+`component/activation.go`, `component/activation_result.go`.
+
+## Run loop
+
+`FMesh.Run()`:
+
+1. `cleanUpPreviousRun` — clears all output ports (prevents signal accumulation between runs), resets `RuntimeInfo`. A mesh is re-runnable.
+2. `beforeRun` hooks — includes a **default hook that validates mesh structure** (parent-mesh/parent-component wiring, pipe destinations belong to the same mesh). Validation runs on **every** `Run`, in component-name order (deterministic errors).
+3. Loop: `runCycle` → `mustStop` → `drainComponents`. Note the order — stop conditions are checked **before** draining, so the final cycle's outputs are not flushed.
+4. `afterRun` hooks fire in a defer; an afterRun hook error is only surfaced when the run itself did not already fail.
+
+`Run` returns `(*RuntimeInfo, error)`. `RuntimeInfo.Cycles` holds every executed cycle with all activation results — the primary observability surface.
+
+## One cycle (`runCycle`)
+
+- Every component gets `MaybeActivate()` called in **its own goroutine**; the cycle waits on a `WaitGroup`. There is no per-cycle ordering between components.
+- `MaybeActivate` returns `ActivationCodeNoInput` without running `f` when **no input port has signals**. A single signal on any one input makes the component "ready" — the activation function must handle partial inputs itself (or return `ErrWaitingForInputs*`).
+- The cycle is always appended to `RuntimeInfo.Cycles`, even when it errored.
+- An empty mesh (`Run` with zero components) is a cycle error (`errNoComponents`).
+
+## Activation result codes
+
+`ActivationResultCode` (in `component/activation_result.go`): `OK`, `NoInput`,
+`ReturnedError`, `Panicked`, `WaitingForInputsClear`, `WaitingForInputsKeep`, `HookFailed`.
+Panics inside activation functions are recovered (with stack trace) and become `Panicked`
+results — a component panic never crashes the mesh; the error strategy decides whether the run
+stops. `IsError()` is true for both `ReturnedError` and `HookFailed` results, so component-level
+hook failures stop the mesh under `StopOnFirstErrorOrPanic` and surface in `Run()`'s error.
+
+## Waiting-for-inputs protocol
+
+Control-flow sentinels in `component/errors.go` — returned **by activation functions**, not real failures:
+
+- `ErrWaitingForInputs` — skip this cycle; the scheduler **clears** the component's inputs.
+- `ErrWaitingForInputsKeep` — skip this cycle; inputs are **kept** for the next cycle (use when accumulating partial inputs, e.g. waiting for both operands).
+
+A component that reported waiting is not drained (its outputs are not flushed) and does not count as an "error" under any strategy.
+
+## Drain phase (`drainComponents`)
+
+After each non-final cycle: clear inputs of activated components (except `WaitingForInputsKeep`),
+then `FlushOutputs` on every component that activated (except those waiting for input).
+Components are drained in **name order** (`Collection.AllOrdered`), so fan-in signal order is
+deterministic. `Flush` fans out **the same `*Signal` pointers** to all connected inputs, then
+clears the source port (only when all deliveries succeeded — errors are joined). Flushing a port
+with no signals or no pipes is a no-op, not an error.
+
+## Stop conditions (`mustStop`, checked in order)
+
+1. Cycle limit hit (`config.CyclesLimit`, default **1000**; 0 = unlimited) → `ErrReachedMaxAllowedCycles`
+2. Time limit hit (`config.TimeLimit`, default **5s**; 0 = unlimited) → `ErrTimeLimitExceeded`. Checked between cycles only — a running activation function is never interrupted.
+3. Error strategy (`config.ErrorHandlingStrategy`, default `StopOnFirstErrorOrPanic`) — checked **before** the natural stop so errors are never swallowed:
+   - `StopOnFirstErrorOrPanic` → stop with `ErrHitAnErrorOrPanic` (includes hook failures)
+   - `StopOnFirstPanic` → errors ignored, panics stop with `ErrHitAPanic`
+   - `IgnoreAll` → run until natural stop or a limit
+4. **Natural stop**: no component activated in the last cycle → `nil` error. This is the normal termination path — a mesh with a loopback pipe or a self-feeding component never stops naturally.
+
+When writing tests that expect limits to trigger, remember the defaults: an infinite mesh stops at cycle 1001 or 5s, whichever comes first.
+
+## Component state
+
+`component.State` (`map[string]any`) persists across cycles and across `Run`s; it is only reset
+via `ResetState()` or `WithInitialState`. Safe without locks because a component activates at
+most once per cycle in a single goroutine. Rich API: `Get`, `GetOrDefault`, `Set`, `SetIfAbsent`,
+`Upsert` (creates if missing), `Update` (only if present), `Delete`, and the generic
+`component.MustGetTyped[T](state, key)` (panics on missing key or wrong type — fine inside
+activation functions, panics become `Panicked` results).

--- a/.agent/docs/testing.md
+++ b/.agent/docs/testing.md
@@ -14,6 +14,6 @@
 - CoW invariant: verify receiver is unchanged after every mutating method on `signal.Signal` and `signal.Group`
 - Edge cases: nil payload, empty group/collection, missing scalar name
 - `meta.Scalars`: `Min`/`Max` return `ok=false` on empty store; `Average` returns `ok=false` on empty store; `Sum` of empty = 0
-- Cross-entity aggregation on groups: `AvgScalar`/`MinScalar`/`MaxScalar` return `ok=false` when no element has the named scalar; `SumScalar` returns 0
+- Cross-entity aggregation on `signal.Group`: `AvgScalar`/`MinScalar`/`MaxScalar` return `signal.ErrScalarNotFoundInGroup` when no element has the named scalar; `SumScalar` returns 0
 - Group metadata separation: group's own Labels/Scalars must not bleed into element Labels/Scalars and vice versa
 - `signal.Group` batch methods (`WithLabelOnEach`, `WithScalarOnEach`, etc.) must preserve the group's own metadata on the returned group

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ labels/        hook/          integration_tests/
 ## Reference docs
 
 - [Design](.agent/docs/design.md) — architecture, invariants, package rules
+- [Runtime](.agent/docs/runtime.md) — run loop, activation lifecycle, stop conditions, state
+- [Hooks](.agent/docs/hooks.md) — hook levels, semantics, plugins
 - [Naming](.agent/docs/naming.md) — CoW vs mutating, method naming
 - [Testing](.agent/docs/testing.md) — style, what to cover
 - [Workflow](.agent/docs/workflow.md) — how to work safely

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Authoritative docs
+
+This repo already carries detailed agent guidance. Read it before making changes — do not
+duplicate or contradict it here:
+
+- `AGENTS.md` — top-level agent guide (layout, priorities, git rules)
+- `.agent/docs/design.md` — architecture, invariants, per-package rules
+- `.agent/docs/runtime.md` — run loop, activation lifecycle, stop conditions, component state
+- `.agent/docs/hooks.md` — hook levels (mesh/component/port), semantics, plugins
+- `.agent/docs/naming.md` — `With`/`Set`/`Add` conventions, CoW vs mutating
+- `.agent/docs/testing.md` — test style and required coverage
+- `.agent/docs/workflow.md` — safe editing/rename practices
+- `.agent/plans/` — historical implementation plans (reference only)
+
+## Commands
+
+```bash
+make test    # go test ./...
+make race    # go test -race ./...   (concurrency is core — run this for scheduler/port changes)
+make lint    # golangci-lint run ./...
+make fix     # golangci-lint run --fix
+make fmt     # go fmt ./...
+make check   # race + lint
+make bench   # go test -bench with -benchmem (no unit tests)
+make deps    # go mod tidy
+```
+
+Single test: `go test ./signal/ -run TestSignal_WithLabel -v`
+Single package: `go test ./component/...`
+Integration suites live in `integration_tests/<topic>/` and run as normal `go test`.
+
+Verify before finishing: `make test && make lint && make fmt`. Key linters enforced:
+`errcheck`, `govet` (shadow), `prealloc`, `dupl`, `gocyclo` (min-complexity 15), `testifylint`,
+`gosec`. Config: `.golangci.yml`. Go 1.26.
+
+## Hard rules
+
+- **Never `git commit`/`git push`, amend, or rewrite history.**
+- **Public API changes require explicit user approval.** Adapting internal callers does not.
+- Ask before relaxing a constraint or introducing a new pattern/helper/abstraction.
+
+## Architecture in one pass
+
+F-Mesh is a Flow-Based Programming framework. An app is a directed graph of **components**
+connected by **pipes** between **ports**; data flows as **signals**; execution runs in discrete
+synchronized **cycles**. Priority is **simplicity and a clean API, not performance.**
+
+Root package `fmesh` orchestrates; the graph primitives live in subpackages:
+
+| Concept | Type | Package |
+|---|---|---|
+| Data packet | `*signal.Signal` | `signal` |
+| Ordered signal collection | `*signal.Group` | `signal` |
+| Data endpoint | `*port.Port` | `port` |
+| Connection (output→input) | `PipeTo` | `port` |
+| Building block | `*component.Component` | `component` |
+| Execution tick | `*cycle.Cycle` | `cycle` |
+| String / numeric metadata | `*meta.Labels` / `*meta.Scalars` | `meta` |
+
+**Execution loop** (`fmesh.go` `Run` → `runCycle` → `drainComponents`): each cycle activates all
+ready components concurrently (one goroutine each, `sync.WaitGroup`), collects `ActivationResult`s,
+then drains — clears inputs and flushes outputs through pipes to downstream inputs. The mesh stops
+naturally when no component activated in a cycle, or on cycle limit / time limit / error strategy.
+Components can signal "waiting for input" to keep their inputs for the next cycle. Config
+(`config.go`): `CyclesLimit` default 1000, `TimeLimit` default 5s, `ErrorHandlingStrategy` default
+`StopOnFirstErrorOrPanic` (see `errors.go` for the three strategies).
+
+**The central invariant (`.agent/docs/design.md`):** `signal.Signal` and `signal.Group` are
+**copy-on-write** — mutating methods return a new value, never touch the receiver; payload is
+shallow-copied and `nil` is a valid payload. In contrast `meta.Labels`/`meta.Scalars` and the
+`port`/`component`/`cycle` types **mutate in place**. This split drives the naming convention:
+`With*`/`Without*` = CoW returning new; `Set*`/`Add*`/`Remove*` = mutating. Never mix them.
+
+No generics (FBP needs mixed-type signals in one group); minimise `reflect`; no chainable
+error/"poison object" pattern — fallible methods return `error` last, infallible transforms
+(`Filter`, `Map`, `With*`) return their type directly for fluency.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ lint:
 fix:
 	golangci-lint run ./... --fix
 
+bench:
+	go test -run=^$$ -bench=. -benchmem ./...
+
 check: race lint
 
 deps:

--- a/README.md
+++ b/README.md
@@ -47,46 +47,71 @@ import (
 )
 
 func main() {
-	// Create the mesh
-	fm := fmesh.New("hello world").
-		AddComponents(
-			component.New("concat").
-				AddInputs("i1", "i2").
-				AddOutputs("res").
-				WithActivationFunc(func(c *component.Component) error {
-					word1 := c.InputByName("i1").Signals().FirstPayloadOrDefault("").(string)
-					word2 := c.InputByName("i2").Signals().FirstPayloadOrDefault("").(string)
-					c.OutputByName("res").PutSignals(signal.New(word1 + word2))
-					return nil
-				}),
-			component.New("uppercase").
-				AddInputs("i1").
-				AddOutputs("res").
-				WithActivationFunc(func(c *component.Component) error {
-					str := c.InputByName("i1").Signals().FirstPayloadOrDefault("").(string)
-					c.OutputByName("res").PutSignals(signal.New(strings.ToUpper(str)))
-					return nil
-				}),
-		)
-
-	// Connect components via pipes
-	fm.ComponentByName("concat").OutputByName("res").
-		PipeTo(fm.ComponentByName("uppercase").InputByName("i1"))
-
-	// Set initial inputs
-	fm.ComponentByName("concat").InputByName("i1").PutSignals(signal.New("hello "))
-	fm.ComponentByName("concat").InputByName("i2").PutSignals(signal.New("world!"))
-
-	// Run the mesh
-	_, err := fm.Run()
-	if err != nil {
+	if err := run(); err != nil {
 		fmt.Println("Error:", err)
 		os.Exit(1)
 	}
+}
 
-	// Get results
-	results := fm.ComponentByName("uppercase").OutputByName("res").Signals().FirstPayloadOrNil()
-	fmt.Printf("Result: %v\n", results) // Output: HELLO WORLD!
+func run() error {
+	// Create the components
+	concat, err := component.New("concat",
+		component.WithInputs("i1", "i2"),
+		component.WithOutputs("res"),
+		component.WithActivationFunc(func(this *component.Component) error {
+			word1 := this.InputByName("i1").Signals().FirstPayloadOrDefault("").(string)
+			word2 := this.InputByName("i2").Signals().FirstPayloadOrDefault("").(string)
+			return this.OutputByName("res").PutSignals(signal.New(word1 + word2))
+		}))
+	if err != nil {
+		return err
+	}
+
+	uppercase, err := component.New("uppercase",
+		component.WithInputs("i1"),
+		component.WithOutputs("res"),
+		component.WithActivationFunc(func(this *component.Component) error {
+			str := this.InputByName("i1").Signals().FirstPayloadOrDefault("").(string)
+			return this.OutputByName("res").PutSignals(signal.New(strings.ToUpper(str)))
+		}))
+	if err != nil {
+		return err
+	}
+
+	// Create the mesh
+	fm, err := fmesh.New("hello world")
+	if err != nil {
+		return err
+	}
+	if err = fm.AddComponents(concat, uppercase); err != nil {
+		return err
+	}
+
+	// Connect components via a pipe
+	if err = concat.OutputByName("res").PipeTo(uppercase.InputByName("i1")); err != nil {
+		return err
+	}
+
+	// Set initial inputs
+	if err = concat.InputByName("i1").PutSignals(signal.New("hello ")); err != nil {
+		return err
+	}
+	if err = concat.InputByName("i2").PutSignals(signal.New("world!")); err != nil {
+		return err
+	}
+
+	// Run the mesh
+	if _, err = fm.Run(); err != nil {
+		return err
+	}
+
+	// Get the result
+	result, err := uppercase.OutputByName("res").Signals().FirstPayload()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Result: %v\n", result) // Result: HELLO WORLD!
+	return nil
 }
 ```
 
@@ -106,7 +131,7 @@ fm.SetupHooks(func(h *fmesh.Hooks) {
         fmt.Println("Starting mesh...")
         return nil
     })
-    h.CycleEnd(func(ctx *fmesh.CycleContext) error {
+    h.AfterCycle(func(ctx *fmesh.CycleContext) error {
         fmt.Printf("Cycle #%d complete\n", ctx.Cycle.Number())
         return nil
     })

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,110 @@
+package fmesh
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/hovsep/fmesh/component"
+	"github.com/hovsep/fmesh/signal"
+	"github.com/stretchr/testify/require"
+)
+
+// buildPipelineMesh builds a linear pipeline: c0 -> c1 -> ... -> c(n-1).
+// Each component increments the incoming integer payload by 1.
+func buildPipelineMesh(b *testing.B, componentsCount int) *FMesh {
+	b.Helper()
+
+	fm, err := New("bench-pipeline")
+	require.NoError(b, err)
+
+	components := make([]*component.Component, componentsCount)
+	for i := range componentsCount {
+		c, err := component.New("c"+strconv.Itoa(i),
+			component.WithInputs("in"),
+			component.WithOutputs("out"),
+			component.WithActivationFunc(func(this *component.Component) error {
+				num := this.InputByName("in").Signals().FirstPayloadOrDefault(0).(int)
+				return this.OutputByName("out").PutSignals(signal.New(num + 1))
+			}))
+		require.NoError(b, err)
+		components[i] = c
+	}
+	require.NoError(b, fm.AddComponents(components...))
+
+	for i := 0; i < componentsCount-1; i++ {
+		require.NoError(b, components[i].OutputByName("out").PipeTo(components[i+1].InputByName("in")))
+	}
+
+	return fm
+}
+
+// BenchmarkMeshRunPipeline measures full mesh execution over a linear
+// 10-component pipeline (activation + drain path).
+func BenchmarkMeshRunPipeline(b *testing.B) {
+	fm := buildPipelineMesh(b, 10)
+	firstInput := fm.ComponentByName("c0").InputByName("in")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if err := firstInput.PutSignals(signal.New(0)); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := fm.Run(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkMeshRunFanOut measures mesh execution with one producer fanning out
+// to 10 consumers (flush/forward path).
+func BenchmarkMeshRunFanOut(b *testing.B) {
+	const consumersCount = 10
+
+	fm, err := New("bench-fanout")
+	require.NoError(b, err)
+
+	producer, err := component.New("producer",
+		component.WithInputs("in"),
+		component.WithOutputs("out"),
+		component.WithActivationFunc(func(this *component.Component) error {
+			return this.OutputByName("out").PutSignals(this.InputByName("in").Signals().All()...)
+		}))
+	require.NoError(b, err)
+	require.NoError(b, fm.AddComponents(producer))
+
+	for i := range consumersCount {
+		consumer, err := component.New("consumer"+strconv.Itoa(i),
+			component.WithInputs("in"),
+			component.WithOutputs("out"),
+			component.WithActivationFunc(func(this *component.Component) error {
+				num := this.InputByName("in").Signals().FirstPayloadOrDefault(0).(int)
+				return this.OutputByName("out").PutSignals(signal.New(num * 2))
+			}))
+		require.NoError(b, err)
+		require.NoError(b, fm.AddComponents(consumer))
+		require.NoError(b, producer.OutputByName("out").PipeTo(consumer.InputByName("in")))
+	}
+
+	producerInput := producer.InputByName("in")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if err := producerInput.PutSignals(signal.New(42)); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := fm.Run(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkMeshConstruction measures building a 10-component mesh with ports
+// and pipes (mesh manipulation path).
+func BenchmarkMeshConstruction(b *testing.B) {
+	b.ReportAllocs()
+	for range b.N {
+		buildPipelineMesh(b, 10)
+	}
+}

--- a/signal/group_bench_test.go
+++ b/signal/group_bench_test.go
@@ -1,0 +1,48 @@
+package signal
+
+import (
+	"strconv"
+	"testing"
+)
+
+// benchGroup returns a group of n signals with int payloads and a "v" scalar.
+func benchGroup(n int) *Group {
+	g := NewGroup()
+	for i := range n {
+		g = g.With(New(i).WithScalar("v", float64(i)).WithLabel("idx", strconv.Itoa(i)))
+	}
+	return g
+}
+
+// BenchmarkGroupCoWOps measures the copy-on-write pipeline: With + Map + Filter
+// over a 100-signal group.
+func BenchmarkGroupCoWOps(b *testing.B) {
+	g := benchGroup(100)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = g.With(New(-1)).
+			Map(func(s *Signal) *Signal {
+				return s.WithLabel("mapped", "true")
+			}).
+			Filter(func(s *Signal) bool {
+				return s.PayloadOrDefault(0).(int)%2 == 0
+			})
+	}
+}
+
+// BenchmarkGroupScalarAggregation measures cross-signal scalar aggregation:
+// SumScalar + AvgScalar over a 100-signal group.
+func BenchmarkGroupScalarAggregation(b *testing.B) {
+	g := benchGroup(100)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = g.SumScalar("v")
+		if _, err := g.AvgScalar("v"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Restores the docs/benchmarks commit that was stranded during the stacked-PR merge cascade:

- README Quick Start rewritten against the current API (old example no longer compiled); fix nonexistent CycleEnd hook -> AfterCycle
- Add CLAUDE.md and .agent/docs/{runtime,hooks}.md; sync design/naming/ testing docs with actual code behavior
- Add benchmarks (mesh run/construction, signal CoW/aggregation) and a make bench target