### PR TITLE
Add benchmarks

### DIFF
--- a/.agent/docs/benchmarking.md
+++ b/.agent/docs/benchmarking.md
@@ -1,0 +1,115 @@
+# Benchmarking & Fuzzing
+
+F-Mesh's priority is *simplicity and a clean API, not performance*. Benchmarks here
+are therefore **regression tripwires**, not optimization targets: they exist to catch
+a change that accidentally adds an allocation, a copy, or quadratic behavior. Fuzz
+targets are **invariant guards** — mainly for the copy-on-write (CoW) rule.
+
+## What we measure & why
+
+Every benchmark reports three numbers (via `b.ReportAllocs()`):
+
+- `ns/op` — wall time. On GitHub-hosted runners (shared VMs) this is **noisy**; trust
+  it only as a relative delta over many samples, never as an absolute.
+- `B/op` — bytes allocated per op.
+- `allocs/op` — heap allocation **count**. This is the most stable metric on noisy CI
+  and the best CoW-regression signal: a CoW method's allocation count is effectively an
+  assertion about how many copies it makes. A jump here usually means a stray copy — or,
+  worse, that someone started mutating in place. Watch it first.
+
+## Comparing runs: benchstat
+
+Never eyeball a single run against another — the variance swamps the signal. Use
+[`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat):
+
+```bash
+go test -run='^$' -bench=. -benchmem -count=8 ./... | tee new.txt
+# ...on the other revision...
+benchstat old.txt new.txt
+```
+
+`-count=8` gives benchstat enough samples to estimate variance. In the output, `~`
+means "no statistically significant change" (high p-value) — do not act on it. CI runs
+this automatically per PR (`.github/workflows/bench.yml`) and posts the table as a
+sticky comment. It is **advisory and never fails the check** — don't gate merges on
+runner noise.
+
+## Writing a benchmark
+
+- `b.ReportAllocs()` — always.
+- Prefer `for b.Loop() { ... }` (Go 1.24+) over `for range b.N`. `b.Loop()` runs setup
+  before the loop outside the timer (no manual `b.ResetTimer()` needed for the common
+  case), keeps loop inputs/results alive, and prevents the compiler from eliminating the
+  loop body as dead code.
+- Keep per-iteration setup out of the measured region. If setup can't be hoisted, guard
+  it with `b.StopTimer()`/`b.StartTimer()`.
+- Use `b.RunParallel` only when contended concurrency is the thing under test.
+
+## The headline metric: activation cycles per second
+
+The single most important number for f-mesh is **activation cycles per second** — how
+fast the scheduler drives full run-loop ticks with every component activating each cycle.
+It measures the library overhead added *on top of* the user's activation function, so
+`BenchmarkMeshThroughput{Dummy,Bypass}` keep the activation body near-empty and report
+custom metrics via `b.ReportMetric`: `cycles/s` and `activations/s` (= cycles/s × size).
+
+Two kinds isolate different overheads, swept over tens/hundreds/thousands of components:
+
+- **dummy** — activation returns `component.ErrWaitingForInputsKeep`, so each component
+  keeps its input and re-activates every cycle with no output ports or pipes. This is the
+  scheduling/activation floor (goroutine fan-out, `WaitGroup`, result collection).
+- **bypass** — activation copies input→output through a self-loop pipe, adding the real
+  per-cycle drain/flush/forward cost.
+
+`bypass − dummy` approximates the cost of the signal-movement path. To sustain N cycles
+per `Run`, the mesh sets `WithCyclesLimit(N)` + `WithUnlimitedTime()`; the expected stop
+error is `ErrReachedMaxAllowedCycles` (not a failure). Inputs are re-primed each `Run`
+because the cycle-limit stop skips the final drain and does not carry signal state across
+`Run` calls.
+
+## Size sweeps reveal complexity class
+
+A fixed-size benchmark is a single point and hides scaling behavior. Sweep the size so
+the shape of the curve is visible:
+
+```go
+for _, n := range []int{10, 100, 1_000, 10_000} {
+    b.Run(strconv.Itoa(n), func(b *testing.B) { /* ... */ })
+}
+```
+
+This is how `BenchmarkGroupBuild` exposes that building a group via repeated `With` is
+O(n²) (each `With` allocates a fresh slice), and how `BenchmarkMeshRunWide` exercises the
+run loop's one-goroutine-per-component-per-cycle cost at scale.
+
+Two mesh-scale gotchas:
+
+- **Wide, not deep.** A linear pipeline of N components needs N cycles; N > `CyclesLimit`
+  (default 1000) or wall time > `TimeLimit` (default 5s) stops the mesh early. Scale
+  benchmarks use *wide* meshes (all components activate in one cycle) or raise the config.
+- **Shallow copy is payload-size independent.** `Signal` CoW copies the interface header,
+  not the pointed-to payload. `BenchmarkGroupPayloadSize` asserts this by keeping `ns/op`
+  flat as payload grows — a tripwire for an accidental deep copy.
+
+## When to add one
+
+Add or extend a benchmark when a change touches a hot path — the run loop
+(`fmesh.go` `runCycle`/`drainComponents`), the port drain/flush path, or any CoW method
+on `signal.Signal`/`signal.Group` — especially if it could add an allocation or a copy.
+
+## Fuzzing
+
+Native Go fuzzing (`func FuzzXxx(f *testing.F)`) guards **properties**, not just crashes.
+The high-value property here is the CoW invariant: a mutating-style method must return a
+new value and leave its receiver untouched (payload, labels, scalars). Targets live
+beside the code they guard (`signal/signal_fuzz_test.go`, `signal/group_fuzz_test.go`).
+
+- Seed corpus runs under normal `go test ./...` (fast, deterministic) — treat it like any
+  table test.
+- Explore for real with a time budget:
+  `go test -run='^$' -fuzz=FuzzSignalCoW -fuzztime=30s ./signal/`
+- Discovered failing inputs are written to `testdata/fuzz/<Target>/` — **commit them**;
+  they become permanent regression cases.
+- Remember `nil` is a valid payload — include it in seeds.
+
+Fuzzing is not in the per-PR workflow (unbounded time); run it locally or on a schedule.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,82 @@
+name: Benchmarks
+
+# Reports performance deltas (PR head vs. base branch) as a sticky PR comment.
+# Advisory only: this workflow never fails the check — GitHub-hosted runners are
+# noisy shared VMs, so benchmark numbers are guidance, not a merge gate.
+# See .agent/docs/benchmarking.md for how to read the output.
+
+on:
+  pull_request
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Cancel superseded runs when the PR is updated (e.g. force-push).
+concurrency:
+  group: bench-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Compare benchmarks (benchstat)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # need base + head commits to benchmark both
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.26"
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      # -count=8 lets benchstat estimate variance and mark insignificant deltas as "~".
+      - name: Benchmark base branch
+        continue-on-error: true
+        run: |
+          git checkout --quiet ${{ github.event.pull_request.base.sha }}
+          go test -run='^$' -bench=. -benchmem -count=8 ./... | tee base.txt
+
+      - name: Benchmark PR head
+        continue-on-error: true
+        run: |
+          git checkout --quiet ${{ github.event.pull_request.head.sha }}
+          go test -run='^$' -bench=. -benchmem -count=8 ./... | tee pr.txt
+
+      - name: Compare with benchstat
+        continue-on-error: true
+        run: benchstat base.txt pr.txt | tee bench.txt
+
+      # Upsert a single sticky comment (identified by the marker) with the
+      # benchstat table. Dependency-free: uses the gh CLI shipped on the runner.
+      - name: Post results as sticky PR comment
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          MARKER='<!-- fmesh-benchstat -->'
+          {
+            echo "$MARKER"
+            echo '## Benchmark report (advisory)'
+            echo
+            echo 'PR head vs. base branch. `~` = no statistically significant change.'
+            echo 'CI runners are noisy — treat `sec/op` as guidance and trust `allocs/op` most.'
+            echo
+            echo '```'
+            cat bench.txt
+            echo '```'
+          } > comment.md
+
+          existing=$(gh pr view "$PR_NUMBER" --json comments \
+            --jq '.comments[] | select(.body | contains("'"$MARKER"'")) | .url' | tail -n1)
+          if [ -n "$existing" ]; then
+            gh pr comment "$PR_NUMBER" --edit-last --body-file comment.md
+          else
+            gh pr comment "$PR_NUMBER" --body-file comment.md
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ labels/        hook/          integration_tests/
 - [Hooks](.agent/docs/hooks.md) — hook levels, semantics, plugins
 - [Naming](.agent/docs/naming.md) — CoW vs mutating, method naming
 - [Testing](.agent/docs/testing.md) — style, what to cover
+- [Benchmarking](.agent/docs/benchmarking.md) — benchmarks, size sweeps, fuzzing, benchstat CI
 - [Workflow](.agent/docs/workflow.md) — how to work safely
 
 ## Before starting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ duplicate or contradict it here:
 - `.agent/docs/hooks.md` — hook levels (mesh/component/port), semantics, plugins
 - `.agent/docs/naming.md` — `With`/`Set`/`Add` conventions, CoW vs mutating
 - `.agent/docs/testing.md` — test style and required coverage
+- `.agent/docs/benchmarking.md` — benchmark best-practices, size sweeps, fuzzing, benchstat CI
 - `.agent/docs/workflow.md` — safe editing/rename practices
 - `.agent/plans/` — historical implementation plans (reference only)
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ fix:
 bench:
 	go test -run=^$$ -bench=. -benchmem ./...
 
+fuzz:
+	go test -run=^$$ -fuzz=FuzzSignalCoW -fuzztime=30s ./signal/
+	go test -run=^$$ -fuzz=FuzzGroupOps -fuzztime=30s ./signal/
+
 check: race lint
 
 deps:

--- a/benchmarks_scale_test.go
+++ b/benchmarks_scale_test.go
@@ -1,0 +1,85 @@
+package fmesh
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/hovsep/fmesh/component"
+	"github.com/hovsep/fmesh/signal"
+	"github.com/stretchr/testify/require"
+)
+
+// benchSizes is the standard size sweep for scale benchmarks. Sweeping the size
+// (rather than fixing one) makes the complexity class visible in benchstat output.
+var benchSizes = []int{10, 100, 1_000, 10_000}
+
+// buildWideMesh builds a mesh of componentsCount independent components (no pipes
+// between them). Seeding every input and calling Run activates all of them in a
+// single cycle, so this isolates the run loop's one-goroutine-per-component cost.
+//
+// Wide, not deep: a linear pipeline of N components would need N cycles and hit the
+// default CyclesLimit (1000) / TimeLimit (5s). A wide mesh runs in one activation cycle.
+func buildWideMesh(b *testing.B, componentsCount int) *FMesh {
+	b.Helper()
+
+	fm, err := New("bench-wide")
+	require.NoError(b, err)
+
+	components := make([]*component.Component, componentsCount)
+	for i := range componentsCount {
+		c, err := component.New("c"+strconv.Itoa(i),
+			component.WithInputs("in"),
+			component.WithOutputs("out"),
+			component.WithActivationFunc(func(this *component.Component) error {
+				num := this.InputByName("in").Signals().FirstPayloadOrDefault(0).(int)
+				return this.OutputByName("out").PutSignals(signal.New(num + 1))
+			}))
+		require.NoError(b, err)
+		components[i] = c
+	}
+	require.NoError(b, fm.AddComponents(components...))
+
+	return fm
+}
+
+// seedWideMesh puts one signal on every component's input so all activate next cycle.
+func seedWideMesh(b *testing.B, fm *FMesh, componentsCount int) {
+	b.Helper()
+	for i := range componentsCount {
+		in := fm.ComponentByName("c" + strconv.Itoa(i)).InputByName("in")
+		if err := in.PutSignals(signal.New(0)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkMeshRunWide measures full mesh execution when N components all activate in
+// the same cycle — i.e. N concurrent goroutines spawned by the run loop. Sweeping N
+// shows how activation overhead scales with mesh width.
+func BenchmarkMeshRunWide(b *testing.B) {
+	for _, n := range benchSizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			fm := buildWideMesh(b, n)
+			b.ReportAllocs()
+			for b.Loop() {
+				seedWideMesh(b, fm, n)
+				if _, err := fm.Run(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkMeshConstructionScale measures building a linear mesh of N components and
+// pipes. Sweeping N should show construction staying linear.
+func BenchmarkMeshConstructionScale(b *testing.B) {
+	for _, n := range benchSizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				buildPipelineMesh(b, n)
+			}
+		})
+	}
+}

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -31,7 +31,7 @@ func buildPipelineMesh(b *testing.B, componentsCount int) *FMesh {
 	}
 	require.NoError(b, fm.AddComponents(components...))
 
-	for i := 0; i < componentsCount-1; i++ {
+	for i := range componentsCount - 1 {
 		require.NoError(b, components[i].OutputByName("out").PipeTo(components[i+1].InputByName("in")))
 	}
 
@@ -45,8 +45,7 @@ func BenchmarkMeshRunPipeline(b *testing.B) {
 	firstInput := fm.ComponentByName("c0").InputByName("in")
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		if err := firstInput.PutSignals(signal.New(0)); err != nil {
 			b.Fatal(err)
 		}
@@ -89,8 +88,7 @@ func BenchmarkMeshRunFanOut(b *testing.B) {
 	producerInput := producer.InputByName("in")
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		if err := producerInput.PutSignals(signal.New(42)); err != nil {
 			b.Fatal(err)
 		}
@@ -104,7 +102,7 @@ func BenchmarkMeshRunFanOut(b *testing.B) {
 // and pipes (mesh manipulation path).
 func BenchmarkMeshConstruction(b *testing.B) {
 	b.ReportAllocs()
-	for range b.N {
+	for b.Loop() {
 		buildPipelineMesh(b, 10)
 	}
 }

--- a/benchmarks_throughput_test.go
+++ b/benchmarks_throughput_test.go
@@ -1,0 +1,146 @@
+package fmesh
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/hovsep/fmesh/component"
+	"github.com/hovsep/fmesh/signal"
+	"github.com/stretchr/testify/require"
+)
+
+// The headline throughput metric for f-mesh is activation cycles per second: how
+// many full run-loop ticks the scheduler can drive, with all components activating
+// every cycle. It measures the library overhead added on top of the user's activation
+// function, so the activation body here is deliberately near-empty.
+//
+// Reported custom metrics:
+//   - cycles/s      — full activation cycles per second (the headline number)
+//   - activations/s — component activations per second (cycles/s × mesh size)
+//
+// Two activation kinds isolate different parts of the overhead:
+//   - dummy  — the activation returns ErrWaitingForInputsKeep, so each component keeps
+//     its input and re-activates every cycle. No output ports, no pipes: this measures
+//     pure scheduling + activation-lifecycle overhead (goroutine fan-out, WaitGroup,
+//     result collection), with none of the drain/flush machinery.
+//   - bypass — the activation copies input signals to an output port that is piped back
+//     to its own input (self-loop), so one signal circulates per component forever. This
+//     adds the realistic per-cycle cost: PutSignals, drain, and pipe forwarding.
+//
+// bypass minus dummy therefore approximates the cost of f-mesh's signal-movement path.
+
+// cyclesPerRun is how many activation cycles each fm.Run() executes. Large enough to
+// amortize per-Run setup so the measured rate reflects steady-state per-cycle overhead.
+const cyclesPerRun = 200
+
+// throughputSizes covers the mesh scales called out in the design: tens, hundreds,
+// thousands of components.
+var throughputSizes = []struct {
+	name string
+	size int
+}{
+	{"small", 50},
+	{"mid", 500},
+	{"huge", 5000},
+}
+
+type activationKind int
+
+const (
+	activationDummy activationKind = iota
+	activationBypass
+)
+
+// buildThroughputMesh builds a mesh of `size` components that all activate every cycle
+// and sustains that for exactly cyclesPerRun cycles per Run (time limit removed).
+func buildThroughputMesh(b *testing.B, size int, kind activationKind) *FMesh {
+	b.Helper()
+
+	fm, err := New("bench-throughput",
+		WithCyclesLimit(cyclesPerRun),
+		WithUnlimitedTime())
+	require.NoError(b, err)
+
+	components := make([]*component.Component, size)
+	for i := range size {
+		name := "c" + strconv.Itoa(i)
+		switch kind {
+		case activationDummy:
+			c, err := component.New(name,
+				component.WithInputs("in"),
+				component.WithActivationFunc(func(*component.Component) error {
+					// Keep the input and re-activate next cycle without emitting anything.
+					return component.ErrWaitingForInputsKeep
+				}))
+			require.NoError(b, err)
+			components[i] = c
+		case activationBypass:
+			c, err := component.New(name,
+				component.WithInputs("in"),
+				component.WithOutputs("out"),
+				component.WithActivationFunc(func(this *component.Component) error {
+					return this.OutputByName("out").PutSignals(this.InputByName("in").Signals().All()...)
+				}))
+			require.NoError(b, err)
+			components[i] = c
+		}
+	}
+	require.NoError(b, fm.AddComponents(components...))
+
+	if kind == activationBypass {
+		// Self-loop: each output feeds its own input so a signal circulates forever.
+		for _, c := range components {
+			require.NoError(b, c.OutputByName("out").PipeTo(c.InputByName("in")))
+		}
+	}
+
+	return fm
+}
+
+// primeInputs puts exactly one signal on every component's input, clearing first so no
+// signal accumulates across Runs (the "keep" kind retains inputs between Runs).
+func primeInputs(b *testing.B, fm *FMesh, size int) {
+	b.Helper()
+	for i := range size {
+		c := fm.ComponentByName("c" + strconv.Itoa(i))
+		require.NoError(b, c.ClearInputs())
+		require.NoError(b, c.InputByName("in").PutSignals(signal.New(0)))
+	}
+}
+
+func benchmarkThroughput(b *testing.B, size int, kind activationKind) {
+	fm := buildThroughputMesh(b, size, kind)
+
+	var totalCycles int
+	b.ReportAllocs()
+	for b.Loop() {
+		primeInputs(b, fm, size)
+		ri, err := fm.Run()
+		// Hitting the cycle limit is the expected, normal stop for a sustained mesh.
+		if err != nil && !errors.Is(err, ErrReachedMaxAllowedCycles) {
+			b.Fatal(err)
+		}
+		totalCycles += ri.Cycles.Len()
+	}
+
+	secs := b.Elapsed().Seconds()
+	b.ReportMetric(float64(totalCycles)/secs, "cycles/s")
+	b.ReportMetric(float64(totalCycles*size)/secs, "activations/s")
+}
+
+// BenchmarkMeshThroughputDummy measures cycles/s with a near-empty activation function
+// (no signal movement) — the scheduling/activation-lifecycle overhead floor.
+func BenchmarkMeshThroughputDummy(b *testing.B) {
+	for _, s := range throughputSizes {
+		b.Run(s.name, func(b *testing.B) { benchmarkThroughput(b, s.size, activationDummy) })
+	}
+}
+
+// BenchmarkMeshThroughputBypass measures cycles/s with a passthrough activation and a
+// self-loop, exercising the full per-cycle drain/flush/pipe path.
+func BenchmarkMeshThroughputBypass(b *testing.B) {
+	for _, s := range throughputSizes {
+		b.Run(s.name, func(b *testing.B) { benchmarkThroughput(b, s.size, activationBypass) })
+	}
+}

--- a/hook/hook_group_test.go
+++ b/hook/hook_group_test.go
@@ -143,5 +143,4 @@ func TestHookGroup_AdditionalMethods(t *testing.T) {
 		assert.True(t, executed)
 		assert.Equal(t, 1, hg.Len())
 	})
-
 }

--- a/integration_tests/component_hooks/basic_test.go
+++ b/integration_tests/component_hooks/basic_test.go
@@ -430,8 +430,7 @@ func BenchmarkComponentHooks_Overhead(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		b.ResetTimer()
-		for range b.N {
+		for b.Loop() {
 			c.MaybeActivate()
 			if err := c.InputByName("in").PutSignals(signal.New(1)); err != nil {
 				b.Fatal(err)
@@ -455,8 +454,7 @@ func BenchmarkComponentHooks_Overhead(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		b.ResetTimer()
-		for range b.N {
+		for b.Loop() {
 			c.MaybeActivate()
 			if err := c.InputByName("in").PutSignals(signal.New(1)); err != nil {
 				b.Fatal(err)

--- a/signal/group_bench_test.go
+++ b/signal/group_bench_test.go
@@ -20,8 +20,7 @@ func BenchmarkGroupCoWOps(b *testing.B) {
 	g := benchGroup(100)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		_ = g.With(New(-1)).
 			Map(func(s *Signal) *Signal {
 				return s.WithLabel("mapped", "true")
@@ -38,11 +37,55 @@ func BenchmarkGroupScalarAggregation(b *testing.B) {
 	g := benchGroup(100)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		_ = g.SumScalar("v")
 		if _, err := g.AvgScalar("v"); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+// groupBenchSizes is the size sweep for group scale benchmarks.
+var groupBenchSizes = []int{10, 100, 1_000, 10_000}
+
+// BenchmarkGroupBuild measures building a group by repeated With across sizes.
+// With is O(n) per call (it allocates a fresh len+1 slice), so building this way is
+// O(n²) overall — the sweep makes that visible and informs whether a bulk constructor
+// would ever be worth adding.
+func BenchmarkGroupBuild(b *testing.B) {
+	for _, n := range groupBenchSizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				g := NewGroup()
+				for i := range n {
+					g = g.With(New(i))
+				}
+				_ = g
+			}
+		})
+	}
+}
+
+// payloadOfSize returns a byte slice payload of the given size. Because signal CoW is
+// a shallow copy, the payload's size should not affect per-op copy cost.
+func payloadOfSize(size int) []byte {
+	return make([]byte, size)
+}
+
+// BenchmarkGroupPayloadSize runs a CoW pipeline over a single signal while sweeping the
+// payload size. ns/op should stay flat across sizes: CoW copies the interface header,
+// not the pointed-to payload. A rise here means a deep copy crept in.
+func BenchmarkGroupPayloadSize(b *testing.B) {
+	for _, size := range []int{8, 1 << 10, 1 << 16, 1 << 20} {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			s := New(payloadOfSize(size))
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = s.WithLabel("k", "v").
+					WithScalar("n", 1).
+					Map(func(sig *Signal) *Signal { return sig.WithLabel("m", "x") })
+			}
+		})
 	}
 }

--- a/signal/group_fuzz_test.go
+++ b/signal/group_fuzz_test.go
@@ -1,0 +1,69 @@
+package signal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// FuzzGroupOps guards CoW and length invariants on Group: With/Filter/Map/Join return
+// a new group and never mutate the receiver, nil signals in With are skipped, and the
+// resulting lengths follow the documented rules.
+func FuzzGroupOps(f *testing.F) {
+	f.Add(0, 0)
+	f.Add(3, 2)
+	f.Add(50, 10)
+
+	f.Fuzz(func(t *testing.T, nRaw, mRaw int) {
+		// Bound sizes so fuzzing stays fast and can't OOM.
+		n := boundSize(nRaw)
+		m := boundSize(mRaw)
+
+		g := NewGroup()
+		for i := range n {
+			g = g.With(New(i))
+		}
+		lenBefore := g.Len()
+		assert.Equal(t, n, lenBefore)
+
+		// With appends and leaves the receiver untouched.
+		withOne := g.With(New(-1))
+		assert.Equal(t, lenBefore, g.Len(), "With mutated receiver")
+		assert.Equal(t, lenBefore+1, withOne.Len())
+
+		// nil signals are skipped by With.
+		withNil := g.With(nil, nil)
+		assert.Equal(t, lenBefore, withNil.Len(), "With should skip nil signals")
+
+		// Filter never grows the group and never mutates the receiver.
+		filtered := g.Filter(func(s *Signal) bool { return s.PayloadOrDefault(-1).(int)%2 == 0 })
+		assert.Equal(t, lenBefore, g.Len(), "Filter mutated receiver")
+		assert.LessOrEqual(t, filtered.Len(), lenBefore)
+
+		// Map preserves length and leaves the receiver untouched.
+		mapped := g.Map(func(s *Signal) *Signal { return s.WithLabel("m", "1") })
+		assert.Equal(t, lenBefore, g.Len(), "Map mutated receiver")
+		assert.Equal(t, lenBefore, mapped.Len())
+
+		// Join concatenates lengths without mutating either operand.
+		other := NewGroup()
+		for i := range m {
+			other = other.With(New(i))
+		}
+		joined := g.Join(other)
+		assert.Equal(t, lenBefore, g.Len(), "Join mutated receiver")
+		assert.Equal(t, m, other.Len(), "Join mutated argument")
+		assert.Equal(t, lenBefore+m, joined.Len())
+	})
+}
+
+// boundSize clamps a fuzzed count into [0, 1000].
+func boundSize(v int) int {
+	if v < 0 {
+		v = -v
+	}
+	if v < 0 || v > 1000 { // v < 0 catches math.MinInt after negation
+		return 1000
+	}
+	return v
+}

--- a/signal/signal_fuzz_test.go
+++ b/signal/signal_fuzz_test.go
@@ -1,0 +1,62 @@
+package signal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// FuzzSignalCoW guards the copy-on-write invariant: every mutating-style method must
+// return a new *Signal and leave the receiver untouched (payload, labels, scalars).
+// nil is a valid payload, so it is exercised via the nilPayload arm.
+func FuzzSignalCoW(f *testing.F) {
+	f.Add("payload", false, "label", "value", "scalar", 1.5)
+	f.Add("", true, "", "", "", 0.0)
+	f.Add("x", false, "k", "", "s", -3.0)
+
+	f.Fuzz(func(t *testing.T,
+		payloadStr string, nilPayload bool,
+		labelKey, labelVal, scalarName string, scalarVal float64,
+	) {
+		var payload any = payloadStr
+		if nilPayload {
+			payload = nil
+		}
+		s := New(payload)
+
+		// Snapshot the receiver's observable state.
+		labelsBefore := s.Labels().All()
+		scalarsBefore := s.Scalars().All()
+		payloadBefore := s.PayloadOrNil()
+
+		assertUnchanged := func(what string) {
+			assert.Equal(t, labelsBefore, s.Labels().All(), "%s mutated receiver labels", what)
+			assert.Equal(t, scalarsBefore, s.Scalars().All(), "%s mutated receiver scalars", what)
+			assert.Equal(t, payloadBefore, s.PayloadOrNil(), "%s mutated receiver payload", what)
+		}
+
+		// WithLabel: returns new, receiver unchanged, round-trips the value.
+		withLabel := s.WithLabel(labelKey, labelVal)
+		assertUnchanged("WithLabel")
+		assert.Equal(t, labelVal, withLabel.Labels().ValueOrDefault(labelKey, "\x00sentinel"))
+
+		// WithScalar: same guarantees.
+		withScalar := s.WithScalar(scalarName, scalarVal)
+		assertUnchanged("WithScalar")
+		assert.True(t, withScalar.Scalars().ValueIs(scalarName, scalarVal))
+
+		// WithoutLabels removes from the copy but not from its source.
+		without := withLabel.WithoutLabels(labelKey)
+		assert.True(t, withLabel.Labels().Has(labelKey), "WithoutLabels mutated its source")
+		assert.False(t, without.Labels().Has(labelKey))
+
+		// Map / MapPayload must not touch the receiver's payload.
+		mapped := s.Map(func(sig *Signal) *Signal { return sig.WithLabel("mapped", "true") })
+		assertUnchanged("Map")
+		assert.Equal(t, "true", mapped.Labels().ValueOrDefault("mapped", ""))
+
+		remapped := s.MapPayload(func(any) any { return "remapped" })
+		assertUnchanged("MapPayload")
+		assert.Equal(t, "remapped", remapped.PayloadOrNil())
+	})
+}


### PR DESCRIPTION
This pull request introduces a comprehensive benchmarking and fuzzing framework to the project, with a strong focus on regression detection and code health rather than raw performance optimization. It adds detailed documentation, new benchmark and fuzzing tests, and integrates automated benchmark comparison into CI. Several existing benchmarks are modernized for improved accuracy and maintainability. The most important changes are summarized below.

**Benchmarking and Fuzzing Documentation & CI Integration:**

* Added `.agent/docs/benchmarking.md` with detailed guidance on benchmarking philosophy, best practices, interpreting results, and fuzzing invariants.
* Introduced `.github/workflows/bench.yml` to automatically run benchmarks on PRs, compare results with `benchstat`, and post advisory comments to PRs (not a merge gate).
* Updated `AGENTS.md` and `CLAUDE.md` to reference the new benchmarking documentation. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R23) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R16)

**New and Improved Benchmarks:**

* Added `benchmarks_throughput_test.go` to measure the core throughput metric: activation cycles per second, with both "dummy" (scheduling only) and "bypass" (signal movement) activation types.
* Added `benchmarks_scale_test.go` to sweep mesh sizes and expose scaling behavior for both mesh execution and construction.
* Enhanced `signal/group_bench_test.go` with size sweeps for group construction and payload size, making complexity classes visible and guarding against deep-copy regressions.

**Test and Benchmark Modernization:**

* Replaced legacy `for range b.N` benchmark loops with the modern `for b.Loop()` pattern throughout all benchmarks for more accurate measurement and less boilerplate. [[1]](diffhunk://#diff-46bfe8471bc109bb9dcadacebc0c91e8979486fabed87193fb33e6535d5b7ceeL48-R48) [[2]](diffhunk://#diff-46bfe8471bc109bb9dcadacebc0c91e8979486fabed87193fb33e6535d5b7ceeL92-R91) [[3]](diffhunk://#diff-46bfe8471bc109bb9dcadacebc0c91e8979486fabed87193fb33e6535d5b7ceeL107-R105) [[4]](diffhunk://#diff-0d2d316fc517fcc11d7ebf8c27688a5d71949fdcfbe0a92718327994cd883007L23-R23) [[5]](diffhunk://#diff-fc6dc50fc8c59fc28d3ffa301ddeaadd4a8bb3c12a56ad697cfdaceb8c680409L433-R433) [[6]](diffhunk://#diff-fc6dc50fc8c59fc28d3ffa301ddeaadd4a8bb3c12a56ad697cfdaceb8c680409L458-R457)
* Minor loop idiom fixes for clarity and correctness in mesh construction.

**Developer Workflow Improvements:**

* Added `fuzz` target to `Makefile` for running fuzz tests on core invariants, making it easy to execute fuzzing locally.

These changes together provide robust, scalable, and easy-to-use infrastructure for performance regression detection and invariant checking, making it easier to maintain code quality as the project evolves.