### PR TITLE
add scalability benchmark

### DIFF
--- a/.agent/docs/benchmarking.md
+++ b/.agent/docs/benchmarking.md
@@ -82,7 +82,7 @@ This is how `BenchmarkGroupBuild` exposes that building a group via repeated `Wi
 O(n²) (each `With` allocates a fresh slice), and how `BenchmarkMeshRunWide` exercises the
 run loop's one-goroutine-per-component-per-cycle cost at scale.
 
-Two mesh-scale gotchas:
+Mesh-scale gotchas:
 
 - **Wide, not deep.** A linear pipeline of N components needs N cycles; N > `CyclesLimit`
   (default 1000) or wall time > `TimeLimit` (default 5s) stops the mesh early. Scale
@@ -90,6 +90,14 @@ Two mesh-scale gotchas:
 - **Shallow copy is payload-size independent.** `Signal` CoW copies the interface header,
   not the pointed-to payload. `BenchmarkGroupPayloadSize` asserts this by keeping `ns/op`
   flat as payload grows — a tripwire for an accidental deep copy.
+- **Fan-in is quadratic.** Pipe forwarding appends to the destination port one signal at a
+  time, and each append copies the destination's whole signal group (`port.putSignals` →
+  `signal.Group.With`) — so N outputs converging on one input port cost O(N²) in the drain.
+  `BenchmarkMeshFanIn` sweeps this curve; it flattens to linear only if forwarding ever
+  batches appends. See "Scaling characteristics" in `runtime.md` for the practical limits.
+- **Long benchmarks accumulate runtime history.** `RuntimeInfo.Cycles` retains every cycle's
+  activation results for the whole `Run` (~100 B × components × cycles), so `B/op` in
+  sustained-cycle benchmarks includes history growth, not just the signal path.
 
 ## When to add one
 

--- a/.agent/docs/runtime.md
+++ b/.agent/docs/runtime.md
@@ -12,7 +12,7 @@ How a mesh actually runs. Source: `fmesh.go` (`Run`, `runCycle`, `drainComponent
 3. Loop: `runCycle` → `mustStop` → `drainComponents`. Note the order — stop conditions are checked **before** draining, so the final cycle's outputs are not flushed.
 4. `afterRun` hooks fire in a defer; an afterRun hook error is only surfaced when the run itself did not already fail.
 
-`Run` returns `(*RuntimeInfo, error)`. `RuntimeInfo.Cycles` holds every executed cycle with all activation results — the primary observability surface.
+`Run` returns `(*RuntimeInfo, error)`. `RuntimeInfo.Cycles` holds every executed cycle with all activation results — the primary observability surface. Note this history is retained for the whole run and grows without bound — see "Scaling characteristics" below.
 
 ## One cycle (`runCycle`)
 
@@ -59,6 +59,27 @@ with no signals or no pipes is a no-op, not an error.
 4. **Natural stop**: no component activated in the last cycle → `nil` error. This is the normal termination path — a mesh with a loopback pipe or a self-feeding component never stops naturally.
 
 When writing tests that expect limits to trigger, remember the defaults: an infinite mesh stops at cycle 1001 or 5s, whichever comes first.
+
+## Scaling characteristics (measured)
+
+Empirical envelope from stress experiments (July 2026, 8-core/16 GiB arm64 laptop). The
+absolute numbers are machine-specific; the complexity classes are the durable part.
+
+- **Width scales near-linearly.** ~1.5–4 µs of scheduler overhead per component per cycle
+  and ~300 B of heap per component: a 10⁶-component mesh builds in ~2 s and runs a
+  one-wave computation in ~10 s. But `runCycle` spawns one goroutine per component per
+  cycle — ready or not — so at 10⁷ components the goroutine stacks alone (tens of GiB)
+  are an OOM risk before speed becomes the problem.
+- **Fan-in is O(N²).** `ForwardSignals` appends one signal at a time, and each append
+  copies the destination port's whole signal group (`port.putSignals` →
+  `signal.Group.With`). N outputs converging on a single input port become impractical
+  around N ≈ 10⁵ (tens of seconds spent in one drain). Guarded by `BenchmarkMeshFanIn`.
+- **Long-running meshes are memory-bound, not time-bound.** Per-cycle cost stays flat as
+  cycle count grows (~10³–10⁴ cycles/s depending on width), but `RuntimeInfo.Cycles`
+  retains an `ActivationResult` for every component in every cycle (~100 B × components ×
+  cycles) and nothing is freed during `Run` — even though the run loop itself only reads
+  `Cycles.Last()`. 100 components × 10⁵ cycles already holds ~1 GiB. Rule of thumb: keep
+  components × cycles per `Run` under ~10⁸ on a 16 GiB machine.
 
 ## Component state
 

--- a/benchmarks_scale_test.go
+++ b/benchmarks_scale_test.go
@@ -71,6 +71,62 @@ func BenchmarkMeshRunWide(b *testing.B) {
 	}
 }
 
+// buildFanInMesh builds componentsCount source components whose outputs all pipe into a
+// single collector input. Draining cycle 1 forwards one signal per source into the same
+// destination port, and each append copies the collector's whole signal group
+// (port.putSignals → signal.Group.With), so the drain is O(N²) in the number of sources.
+func buildFanInMesh(b *testing.B, componentsCount int) *FMesh {
+	b.Helper()
+
+	fm, err := New("bench-fan-in")
+	require.NoError(b, err)
+
+	collector, err := component.New("collector",
+		component.WithInputs("in"),
+		component.WithActivationFunc(func(*component.Component) error {
+			// Consume silently: the measured cost is the fan-in drain, not the collector.
+			return nil
+		}))
+	require.NoError(b, err)
+
+	sources := make([]*component.Component, componentsCount)
+	for i := range componentsCount {
+		c, err := component.New("c"+strconv.Itoa(i),
+			component.WithInputs("in"),
+			component.WithOutputs("out"),
+			component.WithActivationFunc(func(this *component.Component) error {
+				num := this.InputByName("in").Signals().FirstPayloadOrDefault(0).(int)
+				return this.OutputByName("out").PutSignals(signal.New(num + 1))
+			}))
+		require.NoError(b, err)
+		require.NoError(b, c.OutputByName("out").PipeTo(collector.InputByName("in")))
+		sources[i] = c
+	}
+	require.NoError(b, fm.AddComponents(sources...))
+	require.NoError(b, fm.AddComponents(collector))
+
+	return fm
+}
+
+// BenchmarkMeshFanIn measures full mesh execution when N sources all pipe into one
+// collector input — the fan-in topology. Sweeping N is the tripwire for the drain's
+// per-signal-append group copying: today the curve is quadratic; if pipe forwarding
+// ever batches appends into the destination port, it flattens to linear.
+func BenchmarkMeshFanIn(b *testing.B) {
+	for _, n := range benchSizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			fm := buildFanInMesh(b, n)
+			b.ReportAllocs()
+			for b.Loop() {
+				seedWideMesh(b, fm, n)
+				if _, err := fm.Run(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 // BenchmarkMeshConstructionScale measures building a linear mesh of N components and
 // pipes. Sweeping N should show construction staying linear.
 func BenchmarkMeshConstructionScale(b *testing.B) {


### PR DESCRIPTION
This pull request adds comprehensive documentation and benchmarking for the scaling characteristics of mesh topologies, with a particular focus on fan-in scenarios. It introduces a new benchmark to measure the performance impact of multiple sources piping into a single collector, and updates the documentation to clarify the quadratic cost of fan-in and the memory growth from retaining runtime history.

**Benchmarks and Testing Enhancements:**

* Added `buildFanInMesh` and `BenchmarkMeshFanIn` to `benchmarks_scale_test.go` to empirically measure the O(N²) cost when N sources pipe into one collector input, serving as a tripwire for future optimizations in pipe forwarding.

**Documentation Improvements:**

* Expanded `.agent/docs/benchmarking.md` to detail mesh-scale gotchas, including the quadratic cost of fan-in and the unbounded memory growth from retaining `RuntimeInfo.Cycles` history.
* Updated `.agent/docs/runtime.md` to clarify that `RuntimeInfo.Cycles` retains all activation results for the entire run, and added a new "Scaling characteristics" section summarizing empirical findings on width scaling, fan-in cost, and memory usage in long-running meshes. [[1]](diffhunk://#diff-d0fa2de86f60b62701b9d7a515d92b475a57d9da114ff1ae979db01148377829L15-R15) [[2]](diffhunk://#diff-d0fa2de86f60b62701b9d7a515d92b475a57d9da114ff1ae979db01148377829R63-R83)