### PR TITLE
Add CyclesHistoryLimit option

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,10 @@ type Config struct {
 	// can exceed the limit.
 	// 0 means no limit (use WithUnlimitedTime to express this explicitly).
 	TimeLimit time.Duration
+
+	// CyclesHistoryLimit defines the maximum number of past cycles retained in
+	// RuntimeInfo.Cycles; 0 means unlimited (the default).
+	CyclesHistoryLimit int
 }
 
 // newDefaultConfig returns a safe default configuration.
@@ -32,6 +36,7 @@ func newDefaultConfig() Config {
 		CyclesLimit:           1000,
 		Debug:                 false,
 		TimeLimit:             5 * time.Second,
+		CyclesHistoryLimit:    0,
 	}
 }
 
@@ -95,6 +100,27 @@ func WithUnlimitedTime() Option {
 func WithDebug(enabled bool) Option {
 	return func(fm *FMesh) error {
 		fm.config.Debug = enabled
+		return nil
+	}
+}
+
+// WithCyclesHistoryLimit is an FMesh option that sets the maximum number of past cycles
+// retained in RuntimeInfo.Cycles. limit must be greater than 0. Use WithUnlimitedCyclesHistory
+// to remove the limit.
+func WithCyclesHistoryLimit(limit int) Option {
+	return func(fm *FMesh) error {
+		if limit <= 0 {
+			return errors.New("cycles history limit must be greater than 0, use WithUnlimitedCyclesHistory() to remove the limit")
+		}
+		fm.config.CyclesHistoryLimit = limit
+		return nil
+	}
+}
+
+// WithUnlimitedCyclesHistory is an FMesh option that removes the cycles history retention limit.
+func WithUnlimitedCyclesHistory() Option {
+	return func(fm *FMesh) error {
+		fm.config.CyclesHistoryLimit = 0
 		return nil
 	}
 }

--- a/cycle/group.go
+++ b/cycle/group.go
@@ -8,9 +8,12 @@ import (
 
 // Group contains multiple activation cycles.
 type Group struct {
-	cycles  []*Cycle
-	labels  *meta.Labels
-	scalars *meta.Scalars
+	cycles []*Cycle
+	// lenLimit caps how many cycles the group retains; 0 means unlimited.
+	// When Add would exceed the limit, the oldest cycles are evicted.
+	lenLimit int
+	labels   *meta.Labels
+	scalars  *meta.Scalars
 }
 
 // NewGroup creates a group of cycles.
@@ -69,12 +72,52 @@ func (g *Group) RemoveScalarOnEach(names ...string) *Group {
 	return g
 }
 
-// Add adds cycles to the group and returns it.
+// SetLenLimit caps how many cycles the group retains and returns the group.
+// A limit of 0 (or negative) means unlimited. When an Add pushes the group past
+// the limit, the oldest cycles are evicted; the limit is also applied
+// immediately if the group already exceeds it.
+func (g *Group) SetLenLimit(limit int) *Group {
+	if limit < 0 {
+		limit = 0
+	}
+	g.lenLimit = limit
+	g.evictExcess()
+	return g
+}
+
+// Add adds cycles to the group and returns it. When a length limit is set
+// (SetLenLimit), adding beyond it evicts the oldest cycles.
 // Note: Unlike other collections, cycle errors are NOT propagated to the group
 // because cycles represent historical execution records - users need to access
 // cycles that had errors to understand what happened.
 func (g *Group) Add(cycles ...*Cycle) *Group {
 	g.cycles = append(g.cycles, cycles...)
+	g.evictExcess()
+	return g
+}
+
+// evictExcess removes the oldest cycles beyond the configured length limit.
+func (g *Group) evictExcess() {
+	if g.lenLimit > 0 && g.Len() > g.lenLimit {
+		g.RemoveOldest(g.Len() - g.lenLimit)
+	}
+}
+
+// RemoveOldest removes the count oldest cycles (from the front of the group) in place and
+// returns the group. count is clamped to [0, Len()]. Evicted cycles are cleared from the
+// backing array so they become unreachable and can be garbage-collected.
+func (g *Group) RemoveOldest(count int) *Group {
+	if count <= 0 {
+		return g
+	}
+	if count > g.Len() {
+		count = g.Len()
+	}
+
+	copy(g.cycles, g.cycles[count:])
+	clear(g.cycles[g.Len()-count:])
+	g.cycles = g.cycles[:g.Len()-count]
+
 	return g
 }
 

--- a/cycle/group_test.go
+++ b/cycle/group_test.go
@@ -76,6 +76,144 @@ func TestGroup_With(t *testing.T) {
 	}
 }
 
+func TestGroup_RemoveOldest(t *testing.T) {
+	newFourCycles := func() *Group {
+		return NewGroup().Add(New().SetNumber(1), New().SetNumber(2), New().SetNumber(3), New().SetNumber(4))
+	}
+
+	tests := []struct {
+		name       string
+		group      *Group
+		count      int
+		assertions func(t *testing.T, group *Group)
+	}{
+		{
+			name:  "remove some",
+			group: newFourCycles(),
+			count: 2,
+			assertions: func(t *testing.T, group *Group) {
+				assert.Equal(t, 2, group.Len())
+				assert.Equal(t, 3, group.First().Number())
+				assert.Equal(t, 4, group.Last().Number())
+			},
+		},
+		{
+			name:  "remove zero",
+			group: newFourCycles(),
+			count: 0,
+			assertions: func(t *testing.T, group *Group) {
+				assert.Equal(t, 4, group.Len())
+				assert.Equal(t, 1, group.First().Number())
+			},
+		},
+		{
+			name:  "remove negative is a no-op",
+			group: newFourCycles(),
+			count: -1,
+			assertions: func(t *testing.T, group *Group) {
+				assert.Equal(t, 4, group.Len())
+			},
+		},
+		{
+			name:  "remove all",
+			group: newFourCycles(),
+			count: 4,
+			assertions: func(t *testing.T, group *Group) {
+				assert.Zero(t, group.Len())
+				assert.Nil(t, group.Last())
+			},
+		},
+		{
+			name:  "count greater than length is clamped",
+			group: newFourCycles(),
+			count: 100,
+			assertions: func(t *testing.T, group *Group) {
+				assert.Zero(t, group.Len())
+			},
+		},
+		{
+			name:  "empty group",
+			group: NewGroup(),
+			count: 2,
+			assertions: func(t *testing.T, group *Group) {
+				assert.Zero(t, group.Len())
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.group.RemoveOldest(tt.count)
+			assert.Same(t, tt.group, result, "RemoveOldest mutates and returns the receiver")
+			if tt.assertions != nil {
+				tt.assertions(t, result)
+			}
+		})
+	}
+}
+
+func TestGroup_SetLenLimit(t *testing.T) {
+	tests := []struct {
+		name       string
+		group      *Group
+		assertions func(t *testing.T, group *Group)
+	}{
+		{
+			name:  "no limit by default",
+			group: NewGroup().Add(New().SetNumber(1), New().SetNumber(2), New().SetNumber(3)),
+			assertions: func(t *testing.T, group *Group) {
+				assert.Equal(t, 3, group.Len())
+			},
+		},
+		{
+			name:  "add beyond the limit evicts the oldest",
+			group: NewGroup().SetLenLimit(2).Add(New().SetNumber(1), New().SetNumber(2), New().SetNumber(3)),
+			assertions: func(t *testing.T, group *Group) {
+				assert.Equal(t, 2, group.Len())
+				assert.Equal(t, 2, group.First().Number())
+				assert.Equal(t, 3, group.Last().Number())
+			},
+		},
+		{
+			name: "limit of 1 keeps only the most recent cycle",
+			group: NewGroup().SetLenLimit(1).
+				Add(New().SetNumber(1)).
+				Add(New().SetNumber(2)).
+				Add(New().SetNumber(3)),
+			assertions: func(t *testing.T, group *Group) {
+				assert.Equal(t, 1, group.Len())
+				assert.Equal(t, 3, group.Last().Number())
+			},
+		},
+		{
+			name:  "setting a limit on an oversized group evicts immediately",
+			group: NewGroup().Add(New().SetNumber(1), New().SetNumber(2), New().SetNumber(3)).SetLenLimit(2),
+			assertions: func(t *testing.T, group *Group) {
+				assert.Equal(t, 2, group.Len())
+				assert.Equal(t, 2, group.First().Number())
+			},
+		},
+		{
+			name:  "zero limit means unlimited",
+			group: NewGroup().SetLenLimit(0).Add(New().SetNumber(1), New().SetNumber(2), New().SetNumber(3)),
+			assertions: func(t *testing.T, group *Group) {
+				assert.Equal(t, 3, group.Len())
+			},
+		},
+		{
+			name:  "negative limit means unlimited",
+			group: NewGroup().SetLenLimit(-5).Add(New().SetNumber(1), New().SetNumber(2), New().SetNumber(3)),
+			assertions: func(t *testing.T, group *Group) {
+				assert.Equal(t, 3, group.Len())
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertions(t, tt.group)
+		})
+	}
+}
+
 func TestGroup_Without(t *testing.T) {
 	c1 := New().SetNumber(1)
 	c2 := New().SetNumber(2)

--- a/fmesh.go
+++ b/fmesh.go
@@ -35,7 +35,6 @@ func New(name string, opts ...Option) (*FMesh, error) {
 		labels:      meta.NewLabels(),
 		scalars:     meta.NewScalars(),
 		components:  component.NewCollection(),
-		runtimeInfo: newRuntimeInfo(),
 		logger:      newDefaultLogger(name),
 		config:      newDefaultConfig(),
 		hooks:       newHooks(),
@@ -45,6 +44,9 @@ func New(name string, opts ...Option) (*FMesh, error) {
 			return nil, fmt.Errorf("fmesh %q option failed: %w", name, err)
 		}
 	}
+	// Built after the options so the runtime info picks up the configured
+	// history limit (Run rebuilds it the same way).
+	fm.runtimeInfo = newRuntimeInfo(fm.config.CyclesHistoryLimit)
 	return fm, nil
 }
 
@@ -195,7 +197,11 @@ func (fm *FMesh) SetupHooks(configure func(*Hooks)) *FMesh {
 // Returns any error that occurred.
 // The cycle is always added to runtimeInfo even if an error occurred.
 func (fm *FMesh) runCycle() error {
-	newCycle := cycle.New().SetNumber(fm.runtimeInfo.Cycles.Len() + 1)
+	nextNumber := 1
+	if lastCycle := fm.runtimeInfo.Cycles.Last(); lastCycle != nil {
+		nextNumber = lastCycle.Number() + 1
+	}
+	newCycle := cycle.New().SetNumber(nextNumber)
 
 	if err := fm.hooks.beforeCycle.Trigger(&CycleContext{FMesh: fm, Cycle: newCycle}); err != nil {
 		cycleErr := errors.Join(errFailedToRunCycle, fmt.Errorf("beforeCycle hook failed: %w", err))
@@ -217,7 +223,16 @@ func (fm *FMesh) runCycle() error {
 		wg.Add(1)
 		go func(comp *component.Component, cyc *cycle.Cycle) {
 			defer wg.Done()
-			cyc.AddActivationResults(comp.MaybeActivate())
+			ar := comp.MaybeActivate()
+			// Components with no input produce pure noise in runtime info (in sparse
+			// meshes it's most of the history), so their result is never recorded. A
+			// missing result means "had no input"; the run loop treats absent results
+			// as not-activated. Only NoInput is skipped here — WaitingForInputs*,
+			// errors, panics, and HookFailed results are still recorded.
+			if ar.Code() == component.ActivationCodeNoInput {
+				return
+			}
+			cyc.AddActivationResults(ar)
 		}(c, newCycle)
 		return nil
 	})
@@ -256,7 +271,7 @@ func (fm *FMesh) drainComponents() error {
 	for _, c := range components {
 		activationResult := lastCycle.ActivationResults().ByName(c.Name())
 
-		if !activationResult.Activated() {
+		if activationResult == nil || !activationResult.Activated() {
 			// Component did not activate, so it did not create new output signals, hence nothing to drain
 			continue
 		}
@@ -280,7 +295,7 @@ func (fm *FMesh) clearInputs(components []*component.Component) error {
 	for _, c := range components {
 		activationResult := lastCycle.ActivationResults().ByName(c.Name())
 
-		if !activationResult.Activated() {
+		if activationResult == nil || !activationResult.Activated() {
 			// Component did not activate hence its inputs must be clear
 			continue
 		}
@@ -306,7 +321,7 @@ func (fm *FMesh) cleanUpPreviousRun() error {
 	}
 
 	// Init runtime info
-	fm.runtimeInfo = newRuntimeInfo()
+	fm.runtimeInfo = newRuntimeInfo(fm.config.CyclesHistoryLimit)
 	fm.runtimeInfo.MarkStarted()
 	return nil
 }

--- a/fmesh_test.go
+++ b/fmesh_test.go
@@ -289,6 +289,52 @@ func TestWithDebug(t *testing.T) {
 	}
 }
 
+func TestWithCyclesHistoryLimit(t *testing.T) {
+	tests := []struct {
+		name       string
+		limit      int
+		wantErr    bool
+		assertions func(t *testing.T, fm *FMesh)
+	}{
+		{
+			name:  "sets custom limit",
+			limit: 42,
+			assertions: func(t *testing.T, fm *FMesh) {
+				assert.Equal(t, 42, fm.config.CyclesHistoryLimit)
+			},
+		},
+		{
+			name:    "zero is rejected",
+			limit:   0,
+			wantErr: true,
+		},
+		{
+			name:    "negative is rejected",
+			limit:   -1,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fm, err := New("fm1", WithCyclesHistoryLimit(tt.limit))
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, fm)
+				return
+			}
+			require.NoError(t, err)
+			if tt.assertions != nil {
+				tt.assertions(t, fm)
+			}
+		})
+	}
+}
+
+func TestWithUnlimitedCyclesHistory(t *testing.T) {
+	fm := mustNewFMesh("fm1", WithUnlimitedCyclesHistory())
+	assert.Equal(t, 0, fm.config.CyclesHistoryLimit)
+}
+
 func TestWithLogger(t *testing.T) {
 	customLogger := log.New(io.Discard, "test", log.LstdFlags)
 	tests := []struct {
@@ -524,13 +570,9 @@ func TestFMesh_Run(t *testing.T) {
 							SetActivationCode(component.ActivationCodeWaitingForInputsClear).
 							AddActivationError(component.ErrWaitingForInputs),
 					),
-				// Mesh stops naturally in the next cycle because nothing is activated
-				cycle.New().
-					AddActivationResults(
-						component.NewActivationResult("c1").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-					),
+				// Mesh stops naturally in the next cycle because nothing is activated.
+				// c1's NoInput result is not recorded.
+				cycle.New(),
 			),
 			wantErr: false,
 		},
@@ -594,9 +636,9 @@ func TestFMesh_Run(t *testing.T) {
 				mustPutSignals(c1.InputByName("trigger"), signal.New("start"))
 			},
 			wantCycles: cycle.NewGroup().Add(
+				// c2's NoInput result is not recorded (c1 activated).
 				cycle.New().AddActivationResults(
 					component.NewActivationResult("c1").SetActivated(true).SetActivationCode(component.ActivationCodeOK),
-					component.NewActivationResult("c2").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
 				),
 				cycle.New().AddActivationResults(
 					component.NewActivationResult("c1").SetActivated(true).SetActivationCode(component.ActivationCodeOK),
@@ -610,14 +652,12 @@ func TestFMesh_Run(t *testing.T) {
 					component.NewActivationResult("c1").SetActivated(true).SetActivationCode(component.ActivationCodeOK),
 					component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeWaitingForInputsKeep).AddActivationError(component.ErrWaitingForInputsKeep),
 				),
+				// c1's NoInput result is not recorded (c2 activated).
 				cycle.New().AddActivationResults(
-					component.NewActivationResult("c1").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
 					component.NewActivationResult("c2").SetActivated(true).SetActivationCode(component.ActivationCodeOK),
 				),
-				cycle.New().AddActivationResults(
-					component.NewActivationResult("c1").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
-					component.NewActivationResult("c2").SetActivated(false).SetActivationCode(component.ActivationCodeNoInput),
-				),
+				// Neither component activated: no results are recorded.
+				cycle.New(),
 			),
 			wantErr: false,
 		},
@@ -670,48 +710,27 @@ func TestFMesh_Run(t *testing.T) {
 				mustPutSignals(c3.InputByName("i1"), signal.New("start c3"))
 			},
 			wantCycles: cycle.NewGroup().Add(
+				// c2 and c4 had no input this cycle, so their NoInput results are not recorded.
 				cycle.New().
 					AddActivationResults(
 						component.NewActivationResult("c1").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeOK),
-						component.NewActivationResult("c2").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 						component.NewActivationResult("c3").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeReturnedError).
 							AddActivationError(errors.New("component returned an error: boom")),
-						component.NewActivationResult("c4").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 					),
+				// Only c2 activated; c1, c3, c4 had no input.
 				cycle.New().
 					AddActivationResults(
-						component.NewActivationResult("c1").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 						component.NewActivationResult("c2").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeOK),
-						component.NewActivationResult("c3").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c4").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 					),
+				// Only c4 activated (and panicked); c1, c2, c3 had no input.
 				cycle.New().
 					AddActivationResults(
-						component.NewActivationResult("c1").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c2").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c3").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 						component.NewActivationResult("c4").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodePanicked).
@@ -782,103 +801,42 @@ func TestFMesh_Run(t *testing.T) {
 				mustPutSignals(c3.InputByName("i1"), signal.New("start c3"))
 			},
 			wantCycles: cycle.NewGroup().Add(
-				// c1 and c3 activated, c3 finishes with error
+				// c1 and c3 activated, c3 finishes with error; c2, c4, c5 had no input.
 				cycle.New().
 					AddActivationResults(
 						component.NewActivationResult("c1").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeOK),
-						component.NewActivationResult("c2").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 						component.NewActivationResult("c3").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeReturnedError).
 							AddActivationError(errors.New("component returned an error: boom")),
-						component.NewActivationResult("c4").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c5").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 					),
-				// Only c2 is activated
+				// Only c2 is activated; c1, c3, c4, c5 had no input.
 				cycle.New().
 					AddActivationResults(
-						component.NewActivationResult("c1").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 						component.NewActivationResult("c2").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeOK),
-						component.NewActivationResult("c3").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c4").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c5").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 					),
-				// Only c4 is activated and panicked
+				// Only c4 is activated and panicked; c1, c2, c3, c5 had no input.
 				cycle.New().
 					AddActivationResults(
-						component.NewActivationResult("c1").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c2").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c3").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 						component.NewActivationResult("c4").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodePanicked).
 							AddActivationError(errors.New("panicked with: no way")),
-						component.NewActivationResult("c5").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 					),
-				// Only c5 is activated (after c4 panicked in the previous cycle)
+				// Only c5 is activated (after c4 panicked in the previous cycle); the rest had no input.
 				cycle.New().
 					AddActivationResults(
-						component.NewActivationResult("c1").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c2").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c3").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c4").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
 						component.NewActivationResult("c5").
 							SetActivated(true).
 							SetActivationCode(component.ActivationCodeOK),
 					),
-				// Last (control) cycle, no component activated, so f-mesh stops naturally
-				cycle.New().
-					AddActivationResults(
-						component.NewActivationResult("c1").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c2").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c3").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c4").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-						component.NewActivationResult("c5").
-							SetActivated(false).
-							SetActivationCode(component.ActivationCodeNoInput),
-					),
+				// Last (control) cycle: no component activated, so f-mesh stops naturally.
+				// No results are recorded.
+				cycle.New(),
 			),
 			wantErr: false,
 		},

--- a/integration_tests/hooks/fmesh_test.go
+++ b/integration_tests/hooks/fmesh_test.go
@@ -195,7 +195,8 @@ func TestHooks_ContextAccess(t *testing.T) {
 	// Values are from the last cycle (completion cycle)
 	assert.Equal(t, "my-mesh", meshName)
 	assert.Equal(t, 2, cycleNumber)
-	assert.Equal(t, 1, activationCount)
+	// "test" had no input in the completion cycle, so its NoInput result is not recorded.
+	assert.Equal(t, 0, activationCount)
 }
 
 func TestHooks_FireOncePerCycle(t *testing.T) {

--- a/runtime.go
+++ b/runtime.go
@@ -13,10 +13,11 @@ type RuntimeInfo struct {
 	StoppedAt time.Time
 }
 
-// newRuntimeInfo constructor.
-func newRuntimeInfo() *RuntimeInfo {
+// newRuntimeInfo constructor. historyLimit caps how many past cycles are
+// retained in Cycles (0 means unlimited); the group itself enforces the cap.
+func newRuntimeInfo(historyLimit int) *RuntimeInfo {
 	return &RuntimeInfo{
-		Cycles: cycle.NewGroup(),
+		Cycles: cycle.NewGroup().SetLenLimit(historyLimit),
 	}
 }
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -281,4 +281,130 @@ func Test_MultipleRun(t *testing.T) {
 		assert.GreaterOrEqual(t, duration2, int64(50*time.Millisecond))
 		assert.Less(t, duration2, int64(100*time.Millisecond), "Run 2 duration should not be accumulated from Run 1")
 	})
+
+	t.Run("cycles history limit trims retained cycles to a sliding window", func(t *testing.T) {
+		newRepeaterMesh := func(opts ...Option) *FMesh {
+			fm := mustNewFMesh("test fm", opts...)
+			require.NoError(t, fm.AddComponents(
+				mustNewComponent("repeater",
+					component.WithInputs("in"),
+					component.WithOutputs("out"),
+					component.WithActivationFunc(func(this *component.Component) error {
+						count := this.InputByName("in").Signals().FirstPayloadOrDefault(0).(int)
+						if count > 0 {
+							return this.OutputByName("out").PutSignals(signal.New(count - 1))
+						}
+						return nil
+					})),
+			))
+			require.NoError(t, fm.ComponentByName("repeater").OutputByName("out").
+				PipeTo(fm.ComponentByName("repeater").InputByName("in")))
+			return fm
+		}
+
+		t.Run("limit smaller than run length", func(t *testing.T) {
+			fm := newRepeaterMesh(WithCyclesHistoryLimit(3))
+
+			// Observe retention during the run, not only in the returned result:
+			// the retained history must never exceed the limit between cycles.
+			var maxObservedLen int
+			var observedCycles int
+			fm.SetupHooks(func(h *Hooks) {
+				h.AfterCycle(func(ctx *CycleContext) error {
+					observedCycles++
+					if l := ctx.FMesh.runtimeInfo.Cycles.Len(); l > maxObservedLen {
+						maxObservedLen = l
+					}
+					return nil
+				})
+			})
+
+			require.NoError(t, fm.ComponentByName("repeater").InputByName("in").PutSignals(signal.New(5)))
+			runResult, err := fm.Run()
+			require.NoError(t, err)
+
+			// 5 -> 4 -> 3 -> 2 -> 1 -> 0 (6 activated cycles) + 1 empty cycle = 7 total cycles (M = 7)
+			const totalCycles = 7
+			assert.Equal(t, 3, runResult.Cycles.Len())
+			assert.Equal(t, totalCycles, runResult.Cycles.Last().Number())
+			assert.Equal(t, totalCycles-3+1, runResult.Cycles.First().Number())
+
+			// The mesh executed more cycles than it retained, and retention never exceeded the limit mid-run.
+			assert.Equal(t, totalCycles, observedCycles)
+			assert.LessOrEqual(t, maxObservedLen, 3)
+		})
+
+		t.Run("limit larger than run length retains full history", func(t *testing.T) {
+			fm := newRepeaterMesh(WithCyclesHistoryLimit(100))
+			require.NoError(t, fm.ComponentByName("repeater").InputByName("in").PutSignals(signal.New(2)))
+			runResult, err := fm.Run()
+			require.NoError(t, err)
+
+			assert.Equal(t, 4, runResult.Cycles.Len())
+			assert.Equal(t, 1, runResult.Cycles.First().Number())
+			assert.Equal(t, 4, runResult.Cycles.Last().Number())
+		})
+	})
+
+	t.Run("NoInput activation results are never recorded", func(t *testing.T) {
+		newMeshWithIdleComponent := func(opts ...Option) *FMesh {
+			fm := mustNewFMesh("test fm", opts...)
+			require.NoError(t, fm.AddComponents(
+				mustNewComponent("repeater",
+					component.WithInputs("in"),
+					component.WithOutputs("out"),
+					component.WithActivationFunc(func(this *component.Component) error {
+						count := this.InputByName("in").Signals().FirstPayloadOrDefault(0).(int)
+						if count > 0 {
+							return this.OutputByName("out").PutSignals(signal.New(count - 1))
+						}
+						return nil
+					})),
+				// idle never receives any input, so it always reports ActivationCodeNoInput
+				mustNewComponent("idle",
+					component.WithInputs("in"),
+					component.WithOutputs("out"),
+					component.WithActivationFunc(func(this *component.Component) error {
+						return nil
+					})),
+			))
+			require.NoError(t, fm.ComponentByName("repeater").OutputByName("out").
+				PipeTo(fm.ComponentByName("repeater").InputByName("in")))
+			return fm
+		}
+
+		t.Run("idle component's results never appear, mesh still drains and stops correctly", func(t *testing.T) {
+			fm := newMeshWithIdleComponent()
+			require.NoError(t, fm.ComponentByName("repeater").InputByName("in").PutSignals(signal.New(2)))
+			runResult, err := fm.Run()
+			require.NoError(t, err)
+
+			// 2 -> 1 -> 0 (3 activated cycles) + 1 empty cycle = 4 total cycles
+			assert.Equal(t, 4, runResult.Cycles.Len())
+
+			for _, c := range runResult.Cycles.All() {
+				assert.Nil(t, c.ActivationResults().ByName("idle"), "cycle #%d", c.Number())
+
+				repeaterResult := c.ActivationResults().ByName("repeater")
+				if repeaterResult == nil {
+					// repeater itself had no input in the final cycle: its NoInput result is not recorded either.
+					continue
+				}
+				assert.True(t, repeaterResult.Activated())
+				assert.NotEqual(t, component.ActivationCodeNoInput, repeaterResult.Code())
+			}
+		})
+
+		t.Run("combined with a cycles history limit", func(t *testing.T) {
+			fm := newMeshWithIdleComponent(WithCyclesHistoryLimit(2))
+			require.NoError(t, fm.ComponentByName("repeater").InputByName("in").PutSignals(signal.New(5)))
+			runResult, err := fm.Run()
+			require.NoError(t, err)
+
+			assert.Equal(t, 2, runResult.Cycles.Len())
+			for _, c := range runResult.Cycles.All() {
+				assert.Nil(t, c.ActivationResults().ByName("idle"), "cycle #%d", c.Number())
+			}
+		})
+	})
 }


### PR DESCRIPTION
This pull request introduces a configurable limit for how many past cycles are retained in runtime history, and refines how activation results are recorded, especially for components with no input. The main changes add new configuration options, update the `Group` type to support cycle history limits and eviction, and adjust the run loop to skip storing "no input" results. Comprehensive tests are included for these behaviors.

**Cycle history retention and eviction:**

* Added `CyclesHistoryLimit` to the `Config` struct, with corresponding `WithCyclesHistoryLimit` and `WithUnlimitedCyclesHistory` options, allowing users to set or remove a cap on the number of stored cycles (`config.go`, `fmesh.go`). [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R26-R29) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R39) [[3]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R106-R126) [[4]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482L38) [[5]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482R47-R49) [[6]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482L309-R324) [[7]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706R292-R337)
* Updated the `Group` type to include a `lenLimit` field and added methods `SetLenLimit`, `evictExcess`, and `RemoveOldest` to enforce the history limit and evict the oldest cycles when necessary (`cycle/group.go`). [[1]](diffhunk://#diff-391ceb83b586ffb2043b31c6da68f37b07ba0b9bda3a9fd314278b74f564591dR12-R14) [[2]](diffhunk://#diff-391ceb83b586ffb2043b31c6da68f37b07ba0b9bda3a9fd314278b74f564591dL72-R120)

**Activation result recording improvements:**

* The run loop now skips recording activation results for components whose activation code is `NoInput`, reducing noise in runtime history and aligning with intended semantics (`fmesh.go`). [[1]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482L220-R235) [[2]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706L527-R575) [[3]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706R639-L599) [[4]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706R655-R660) [[5]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706R713-L714)

**Testing and validation:**

* Added extensive unit tests for group eviction (`RemoveOldest`, `SetLenLimit`), configuration options, and the new activation result recording logic (`cycle/group_test.go`, `fmesh_test.go`). [[1]](diffhunk://#diff-a1b75bbdd467e42fb63ac57a83ebe9d0e4f0e3ca1a64119ae864e1a38aa5bb4dR79-R216) [[2]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706R292-R337) [[3]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706L527-R575) [[4]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706R639-L599) [[5]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706R655-R660) [[6]](diffhunk://#diff-7349b870160f8bc58929872a196da09c1b180dcf0c1b9447baf11bdb9650f706R713-L714)

**Other improvements:**

* The runtime info is now initialized with the correct history limit after applying options, both on construction and after a run (`fmesh.go`). [[1]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482R47-R49) [[2]](diffhunk://#diff-aef794a230d9667d60e5f3a310cf65d65c5121b85dd1b3d8597ddf441e8d3482L309-R324)
* Fixed cycle numbering to increment based on the last cycle's number, ensuring correct sequence even when history is trimmed (`fmesh.go`).