### PR TITLE
Enhance benchmark workflow: summarize significant deltas in PR commen…

### DIFF
--- a/.agent/docs/benchmarking.md
+++ b/.agent/docs/benchmarking.md
@@ -30,9 +30,9 @@ benchstat old.txt new.txt
 
 `-count=8` gives benchstat enough samples to estimate variance. In the output, `~`
 means "no statistically significant change" (high p-value) — do not act on it. CI runs
-this automatically per PR (`.github/workflows/bench.yml`) and posts the table as a
-sticky comment. It is **advisory and never fails the check** — don't gate merges on
-runner noise.
+this automatically per PR (`.github/workflows/bench.yml`) and posts a sticky comment:
+a summary of statistically significant deltas up top, the full benchstat table collapsed
+below. It is **advisory and never fails the check** — don't gate merges on runner noise.
 
 ## Writing a benchmark
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -52,8 +52,9 @@ jobs:
         continue-on-error: true
         run: benchstat base.txt pr.txt | tee bench.txt
 
-      # Upsert a single sticky comment (identified by the marker) with the
-      # benchstat table. Dependency-free: uses the gh CLI shipped on the runner.
+      # Upsert a single sticky comment (identified by the marker): a short
+      # summary of statistically significant deltas up top, the full benchstat
+      # table collapsed below. Dependency-free: gh CLI ships on the runner.
       - name: Post results as sticky PR comment
         continue-on-error: true
         env:
@@ -61,16 +62,47 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           MARKER='<!-- fmesh-benchstat -->'
+
+          # Rows benchstat marks statistically significant (no "~"). Columns are
+          # separated by 2+ spaces; the metric name carries over from the section header.
+          awk '
+            index($0, "vs base") { split($0, h, "│"); metric = h[2]; gsub(/ /, "", metric); next }
+            /\(p=/ && !/~/ {
+              split($0, col, /  +/)
+              split(col[4], d, " ")
+              printf "| `%s` | %s | %s | %s | %s |\n", col[1], metric, col[2], col[3], d[1]
+            }
+          ' bench.txt > significant.md
+
+          regressions=$(grep -c '| +' significant.md) || true
+          improvements=$(grep -c '| -' significant.md) || true
+
           {
             echo "$MARKER"
             echo '## Benchmark report (advisory)'
             echo
-            echo 'PR head vs. base branch. `~` = no statistically significant change.'
-            echo 'CI runners are noisy — treat `sec/op` as guidance and trust `allocs/op` most.'
+            if ! [ -s bench.txt ]; then
+              echo '⚠️ benchstat produced no output — see the workflow logs.'
+            elif ! [ -s significant.md ]; then
+              echo '**No statistically significant performance changes** (PR head vs. base branch).'
+            else
+              echo "**Statistically significant changes: ${regressions} regression(s), ${improvements} improvement(s)** (PR head vs. base branch)."
+              echo
+              echo '| Benchmark | Metric | Base | PR | Δ |'
+              echo '|---|---|---|---|---|'
+              cat significant.md
+              echo
+              echo 'Higher is worse on every metric. `allocs/op` is the most reliable signal on shared CI runners; treat `sec/op` as guidance.'
+            fi
+            echo
+            echo '<details>'
+            echo '<summary>Full benchstat table</summary>'
             echo
             echo '```'
             cat bench.txt
             echo '```'
+            echo
+            echo '</details>'
           } > comment.md
 
           existing=$(gh pr view "$PR_NUMBER" --json comments \


### PR DESCRIPTION
This pull request improves the clarity and usefulness of benchmark reporting in CI by enhancing both the sticky PR comment and the workflow that generates it. The main change is that the PR comment now includes a concise summary of statistically significant performance changes, making it easier to spot regressions and improvements at a glance, while still providing access to the full data.

**Benchmark reporting improvements:**

* The sticky PR comment now starts with a summary table of statistically significant performance changes (regressions and improvements), followed by the full `benchstat` output collapsed in a details section. This makes it easier to quickly assess the impact of a PR. [[1]](diffhunk://#diff-a5e740be96415373789689f814583e93ff2a8f05eae6481e94505fd6cb6bc6a7L55-R105) [[2]](diffhunk://#diff-06f21704e52735cd0a4eda4e376493219740bb636ca017bb16a84fcdd3231f81L33-R35)
* The workflow uses `awk` to extract and format only statistically significant changes (those not marked with `~` by `benchstat`) into a summary table, and counts regressions and improvements for inclusion in the summary.
* The documentation in `.agent/docs/benchmarking.md` and comments in `.github/workflows/bench.yml` have been updated to reflect the new reporting format and clarify how to interpret the results. [[1]](diffhunk://#diff-06f21704e52735cd0a4eda4e376493219740bb636ca017bb16a84fcdd3231f81L33-R35) [[2]](diffhunk://#diff-a5e740be96415373789689f814583e93ff2a8f05eae6481e94505fd6cb6bc6a7L55-R105)