### PR TITLE
Expand documentation: add "Patterns & Recipes"

### DIFF
--- a/docs/wiki/601.-Tips-&-tricks.md
+++ b/docs/wiki/601.-Tips-&-tricks.md
@@ -148,3 +148,7 @@ Use built-in signal predicates instead of inline closures when possible:
 ```go
 highPriority := port.Signals().Filter(signal.LabelEquals("priority", "high"))
 ```
+
+## Going further
+
+For higher-level techniques — topologies, feedback loops, tick-driven simulations, observing a running mesh — see [Patterns & recipes](https://github.com/hovsep/fmesh/wiki/602.-Patterns-and-recipes).

--- a/docs/wiki/602.-Patterns-and-recipes.md
+++ b/docs/wiki/602.-Patterns-and-recipes.md
@@ -1,0 +1,367 @@
+The previous pages explain the *mechanics* of F-Mesh — this one collects *patterns*: proven ways to structure meshes. Runnable programs demonstrating most of them live in the [fmesh-examples](https://github.com/hovsep/fmesh-examples) repository.
+
+---
+
+## Topology patterns
+
+### Linear pipeline with a generic builder
+
+For a chain of uniform stages, don't hand-wire every pipe — write a builder that accepts components, gives each one standard `in`/`out` ports, tags it with a `stage` label, and pipes stage *N* to stage *N+1*:
+
+```go
+func buildPipeline(name string, components ...*component.Component) (*fmesh.FMesh, error) {
+    for i, c := range components {
+        c.AddLabel("stage", strconv.Itoa(i+1))
+        if err := c.AddInputs("in"); err != nil { return nil, err }
+        if err := c.AddOutputs("out"); err != nil { return nil, err }
+        if i > 0 {
+            prev := components[i-1]
+            if err := prev.OutputByName("out").PipeTo(c.InputByName("in")); err != nil {
+                return nil, err
+            }
+        }
+    }
+    // ... fmesh.New + AddComponents ...
+}
+```
+
+The `stage` label then lets you find the entry and exit points *by role instead of by name*:
+
+```go
+first := fm.Components().FindAny(func(c *component.Component) bool {
+    return c.Labels().ValueIs("stage", "1")
+})
+_ = first.InputByName("in").PutSignals(signal.New("start"))
+```
+
+### Broadcast bus
+
+A star topology where every node talks to every other node through a central *bus* component. Each node is wired bidirectionally (`node.tx → bus.rx`, `bus.tx → node.rx`), and the bus itself is a one-liner:
+
+```go
+component.WithActivationFunc(func(this *component.Component) error {
+    return port.ForwardSignals(this.InputByName("rx"), this.OutputByName("tx"))
+})
+```
+
+Every node receives everything and filters for itself — e.g. by an address kept in its [state](https://github.com/hovsep/fmesh/wiki/301.-Component#stateful-component) or by signal labels. This mirrors real shared-medium protocols, and adding a node never changes existing wiring.
+
+### Fan-in and reduce
+
+When many producers pipe into **one input port**, that port accumulates one signal per producer per cycle. The consumer reads the *whole group* and reduces it:
+
+```go
+var readings []float64
+_ = this.InputByName("in").Signals().ForEach(func(sig *signal.Signal) error {
+    readings = append(readings, sig.PayloadOrDefault(0.0).(float64))
+    return nil
+})
+combined := slices.Min(readings) // or sum, average, majority vote…
+```
+
+Because all producers of the same cycle land together, this is a natural way to model shared-medium effects (arbitration, interference, voting). If your component instead expects exactly one signal, assert it — `Signals().Len() > 1` on such a port usually means a wiring bug.
+
+### Content-based routing
+
+Give the router one output port per destination and decide per signal. Labels are the natural routing key:
+
+```go
+component.WithOutputs("passed", "dropped"),
+component.WithActivationFunc(func(this *component.Component) error {
+    return this.InputByName("in").Signals().ForEach(func(sig *signal.Signal) error {
+        if sig.Labels().ValueIs("genre", "pop") {
+            return this.OutputByName("dropped").PutSignals(sig)
+        }
+        return this.OutputByName("passed").PutSignals(sig)
+    })
+})
+```
+
+`ForEachIf(predicate, action)` and `port.ForwardWithFilter(src, dst, predicate)` express the same idea more compactly — see [Conditional forwarding](https://github.com/hovsep/fmesh/wiki/303.-Pipes#conditional-forwarding).
+
+### Load balancer (dispatch and collect)
+
+[Indexed ports](https://github.com/hovsep/fmesh/wiki/301.-Component#indexed-ports) give you a numbered port family for a variable number of workers; component state holds the round-robin cursor:
+
+```go
+lb, _ := component.New("lb",
+    component.WithInputs("in"), component.WithOutputs("out"),
+    component.WithIndexedOutputs("downstream", 0, numWorkers-1), // to workers
+    component.WithIndexedInputs("upstream", 0, numWorkers-1),    // from workers
+    component.WithInitialState(func(s component.State) { s.Set("next", 0) }),
+    component.WithActivationFunc(func(this *component.Component) error {
+        next := this.State().GetOrDefault("next", 0).(int)
+        _ = this.InputByName("in").Signals().ForEach(func(sig *signal.Signal) error {
+            portName := fmt.Sprintf("downstream%d", next%numWorkers)
+            next++
+            return this.OutputByName(portName).PutSignals(sig)
+        })
+        this.State().Set("next", next)
+        // collect worker responses back into the single egress port
+        for i := 0; i < numWorkers; i++ {
+            _ = port.ForwardSignals(this.InputByName(fmt.Sprintf("upstream%d", i)),
+                this.OutputByName("out"))
+        }
+        return nil
+    }))
+```
+
+Because the cursor lives in state, distribution stays fair even across multiple `Run()` calls on the same mesh.
+
+---
+
+## Feedback loops and generators
+
+### Generator via loopback
+
+A single component whose outputs feed back into its own inputs becomes an iterative process — the mesh's cycles drive the iteration, and the loop state travels through the ports:
+
+```go
+_ = gen.LoopbackPipe("o_prev", "i_prev")
+_ = gen.LoopbackPipe("o_cur", "i_cur")
+
+// bootstrap the loop before Run()
+_ = gen.InputByName("i_prev").PutSignals(signal.New(0))
+_ = gen.InputByName("i_cur").PutSignals(signal.New(1))
+```
+
+### The termination rule: emit to continue, stay silent to stop
+
+A cyclic mesh keeps running only while signals keep arriving. There is no explicit "stop" call — a component ends the loop **by not emitting into it**:
+
+```go
+if next >= limit {
+    return nil // no output ⇒ no next activation ⇒ the mesh stops naturally
+}
+return this.OutputByName("o_cur").PutSignals(signal.New(next))
+```
+
+This is *the* mental model for every cyclic topology. If a loop component unconditionally emits, the loop runs until `CyclesLimit` — which also means the default limits (see [Scheduling rules](https://github.com/hovsep/fmesh/wiki/401.-Scheduling-rules)) act as a useful safety net while you develop.
+
+### Kick-start port
+
+When a feedback loop needs a one-time trigger to begin, give one component a dedicated bootstrap input, seed it before `Run()`, and branch on it inside the activation:
+
+```go
+if this.InputByName("bootstrap").HasSignals() {
+    // first activation: emit the initial signal into the loop, skip normal logic
+    return this.OutputByName("request").PutSignals(signal.New(initialValue))
+}
+// steady state: react to the loop input, re-emit (or stay silent to stop)
+```
+
+### Self-activation heartbeat and countdown
+
+A component with a loopback pipe that re-emits a signal each activation stays alive every cycle — useful for watchdogs, timers, and startup sequences:
+
+```go
+_ = watchdog.LoopbackPipe("keepalive", "keepalive")
+// inside the activation func:
+if !meshIsIdle {
+    _ = this.OutputByName("keepalive").PutSignals(signal.New(true))
+}
+// stop emitting ⇒ the whole mesh quiesces
+```
+
+A variant carries a *countdown* payload: seed `N`, re-emit `N-1` while positive, and you get a component that does something for exactly N cycles.
+
+### Avoiding deadlock inside a feedback loop
+
+If component A consumes B's output *and* B consumes A's, neither can be first within a single tick. The fix: the stateful side **publishes its current state early** (from its own state, before consuming this tick's inputs) and folds the new inputs into state for the *next* tick — accepting one tick of latency:
+
+```go
+// Phase A — a tick arrived: publish the *stored* value immediately,
+// so downstream consumers can proceed within this same run.
+if this.InputByName("time").HasSignals() {
+    level := this.State().GetOrDefault("level", 0.0).(float64)
+    _ = this.OutputByName("level").PutSignals(signal.New(level))
+}
+// Phase B — inputs from peers arrived: update state for the next tick.
+if this.InputByName("updates").HasSignals() {
+    // ...fold updates into this.State()...
+}
+```
+
+---
+
+## Driving a mesh over time
+
+### One mesh, many runs
+
+`Run()` is a one-shot drain: it cycles until no component activates, then returns. But the mesh object survives — **component state persists, input signals persist until consumed, and output ports are cleared at the start of each run**. So a long-lived program can loop: inject inputs, `Run()`, read outputs, repeat.
+
+```go
+for job := range jobs {
+    _ = worker.InputByName("in").PutSignals(signal.New(job))
+    if _, err := fm.Run(); err != nil { break }
+    results, _ := worker.OutputByName("out").Signals().AllPayloads()
+    worker.OutputByName("out").Clear() // don't let stale results accumulate
+    resultsChan <- results
+}
+```
+
+If you read outputs *between* runs (rather than after the final one), `Clear()` them once consumed. Use `fmesh.WithUnlimitedTime()` / `WithUnlimitedCycles()` when a single run may legitimately be slow (e.g. real network I/O inside an activation function).
+
+### Tick-driven simulation
+
+For discrete-time simulations, make the tick a signal. A mesh-level `BeforeRun` hook injects it, a clock component timestamps it, and pipes deliver it to every component that needs time:
+
+```go
+fm.SetupHooks(func(hooks *fmesh.Hooks) {
+    hooks.BeforeRun(func(mesh *fmesh.FMesh) error {
+        return mesh.ComponentByName("clock").InputByName("ctl").PutSignals(signal.New("tick"))
+    })
+})
+```
+
+Pack the tick's fields (sequence number, simulated duration, Δt) as [scalars](https://github.com/hovsep/fmesh/wiki/202.-Metadata) on one signal, so components that integrate over time get the Δt they need. One `Run()` = one tick; call `Run()` in a loop to advance the clock.
+
+### Interactive stepping
+
+A mesh can be stepped interactively — from a REPL, a UI, or a network endpoint. Two rules make this safe and pleasant:
+
+- **Single-goroutine ownership.** Only one goroutine ever touches the mesh (inject, run, read). F-Mesh objects are not synchronized for external concurrent access, so other goroutines communicate with the owner via a channel — a channel of closures works well:
+
+```go
+commands := make(chan func(fm *fmesh.FMesh))
+
+// the owning goroutine:
+for cmd := range commands {
+    cmd(fm)          // e.g. inject a signal, inspect state
+    _, _ = fm.Run()  // advance one step
+}
+
+// any other goroutine:
+commands <- func(fm *fmesh.FMesh) {
+    _ = fm.ComponentByName("source").InputByName("in").PutSignals(signal.New("hello"))
+}
+```
+
+- **Detect idle steps** so you can pause instead of spinning, using the [run report](https://github.com/hovsep/fmesh/wiki/402.-Inspecting-a-run):
+
+```go
+runInfo, _ := fm.Run()
+if runInfo.Cycles.Count(func(c *cycle.Cycle) bool { return c.HasActivatedComponents() }) == 0 {
+    // nothing happened — wait for the next command instead of running again
+}
+```
+
+---
+
+## Structuring a large mesh
+
+### Component factories
+
+Give each component its own constructor returning `(*component.Component, error)`, with errors wrapped at every step. Meshes are then assembled from factories, keeping `main` free of wiring detail. For families of similar components, parameterize the factory (`newWorker(i int)`) and add the results in bulk: `fm.AddComponents(workers...)`.
+
+### Subsystem structs
+
+Group related components in a plain Go struct that knows how to enumerate and connect them:
+
+```go
+type Node struct {
+    Controller, Transmitter, Receiver *component.Component
+}
+
+func (n *Node) AllComponents() []*component.Component { /* ... */ }
+func (n *Node) ConnectTo(bus *Bus) error              { /* internal + bus wiring */ }
+```
+
+`main` stays declarative: build nodes, `fm.AddComponents(node.AllComponents()...)`, `node.ConnectTo(bus)`.
+
+### Nested mesh as a component
+
+A whole mesh can hide behind one component whose activation function runs it — see [Nested meshes](https://github.com/hovsep/fmesh/wiki/301.-Component#nested-meshes) for the mechanics. At scale, structure the wrapper's activation as sequential phases:
+
+1. **validate** — return `component.ErrWaitingForInputsKeep` until all required inputs are present;
+2. **sense** — forward the wrapper's inputs into the inner mesh's input ports (`port.ForwardSignals`);
+3. **act** — `innerMesh.Run()`;
+4. **feedback** — forward inner output ports back to the wrapper's outputs.
+
+Build the inner mesh **once** (in the wrapper's constructor, closed over by the activation function), not on every activation — component state inside the inner mesh then persists across ticks.
+
+### Convention-based wiring
+
+With many components, explicit pipe lists get tedious. Adopt a port-naming convention and wire by lookup — e.g. at assembly time, pipe the clock's output to every component that has an input named `time`, or match inputs named `<subsystem>_<port>` to the corresponding subsystem output. Keep port names as shared constants in one package — pipes should never depend on magic strings.
+
+### Table-driven activation functions
+
+When many components share behavior that differs only in data, generate the activation function from a declarative table instead of writing near-identical closures:
+
+```go
+func activationFromTable(handlers map[string]func(*component.Component, *signal.Signal) error) component.ActivationFunc {
+    return func(this *component.Component) error {
+        return this.InputByName("in").Signals().ForEach(func(sig *signal.Signal) error {
+            if handler, ok := handlers[sig.Labels().ValueOrDefault("cmd", "")]; ok {
+                return handler(this, sig)
+            }
+            return nil // unknown commands are ignored
+        })
+    }
+}
+```
+
+Each component instance is then just a table; the uniform dispatch lives in one place.
+
+---
+
+## Metadata techniques
+
+These build on [Metadata](https://github.com/hovsep/fmesh/wiki/202.-Metadata):
+
+- **Labels as routing keys, not just annotations** — filters route on `sig.Labels().ValueIs(k, v)`; a relay forwards only signals labeled for it.
+- **Find components by role, not name** — `fm.Components().FindAny(...)` over labels like `role=aggregator` or `stage=1` decouples orchestration code from component names.
+- **Pack multi-field values as scalars on one signal** when the fields are numeric and you want them queryable (`signal.New("tick").WithScalar("seq", n).WithScalar("delta_t_ms", dt)`); use a plain struct payload when the value is opaque to the mesh. Pair each `packX` helper with an `unpackX` and unit-test the round trip.
+- **Tag provenance when aggregating** — `port.ForwardWithMap(src, dst, func(s *signal.Signal) *signal.Signal { return s.WithLabel("from", name) })` lets one collector port carry signals from many sources without losing origin.
+- **Bulk-label a group on injection** — `signal.NewGroup(payloads...).Map(func(s *signal.Signal) *signal.Signal { return s.WithLabel("to", "usb") })` then `PutSignalGroups(...)`.
+
+---
+
+## Observing a running mesh
+
+### Aggregator component
+
+Rather than having observers reach into many components, add one *aggregator* component that pipes in every observable port and re-emits everything on a single output — a queryable single source of truth. Its ports can even be created dynamically from a list of `"component::port"` paths at mesh-build time. Tests and UIs then read one component.
+
+### Streaming to the outside world
+
+External consumers (TUIs, dashboards) should never touch the mesh. Publish from an `AfterRun` hook to a sink, and let the consumer read the stream:
+
+```go
+fm.SetupHooks(func(hooks *fmesh.Hooks) {
+    hooks.AfterRun(func(mesh *fmesh.FMesh) error {
+        return mesh.ComponentByName("publisher").OutputByName("stream").Signals().
+            ForEach(func(line *signal.Signal) error {
+                return sink.Publish(line.PayloadOrDefault("").(string))
+            })
+    })
+})
+```
+
+Put the sink behind a small interface (`Publish(line string) error`) so stdout, a socket, or a no-op are interchangeable, and make it **non-blocking and lossy** (buffered channel, drop-and-count on overflow) so a slow observer can never back-pressure the mesh.
+
+### Error side-channels
+
+Give fallible components a dedicated `errors` output port piped to a logger/collector component, and `continue` past per-item failures instead of returning an error (which, under the default strategy, stops the whole mesh). Reserve the returned `error` for genuinely fatal conditions.
+
+---
+
+## Testing patterns
+
+[`MaybeActivate`](https://github.com/hovsep/fmesh/wiki/402.-Inspecting-a-run#testing-a-component-in-isolation) covers single components; for whole-mesh behavior, use **hooks as probes**:
+
+- **Collect a time series** with a component-level `AfterActivation` hook (or a mesh-level `AfterRun` hook reading the aggregator), appending each observed value to a slice while the mesh runs.
+- **Assert properties, not exact values**: monotonically increasing clock, oscillation (sign changes, min–max range), values staying within bounds *and not pinned to a clamp boundary* — robust against timing noise in a way exact-value asserts are not.
+- **Bound simulated time, not wall time**: a hook on the clock component watches simulated duration and triggers shutdown when the target is reached (guard the trigger with `sync.Once` — firing a shutdown command twice into a closed channel is a classic leak).
+- **Unit-test your signal-packing helpers** (pack/unpack round trips, invariants like "shares sum to 100%") separately from the mesh.
+
+---
+
+## Field-tested gotchas
+
+- **A multi-input component activates when *any* input has signals.** If an activation phase must run exactly once per tick, gate it on the specific port: `if !this.InputByName("time").HasSignals() { return nil }`.
+- **`return nil` vs waiting.** Returning `nil` on partial input silently consumes what arrived; `component.ErrWaitingForInputsKeep` re-queues the component *keeping* its buffered inputs until the rest arrive. Choose deliberately — see [Waiting for inputs](https://github.com/hovsep/fmesh/wiki/301.-Component#waiting-for-inputs).
+- **Don't depend on activation order within a cycle.** Components activate concurrently; if a value must be seen "before" another, carry it in state across ticks (see the feedback-loop deadlock pattern above) instead of relying on ordering.
+- **Type-assert payloads with the `, ok` form** at trust boundaries and treat failures as data errors (route to an error port), not panics — payloads are `any`.
+- **Signals fanned out through pipes are shared pointers.** Treat payloads as immutable; transform with `MapPayload`/`With*` copies (see [Signals](https://github.com/hovsep/fmesh/wiki/201.-Signals)).
+- **Outputs are cleared at the start of each `Run()`; inputs persist.** Read (and if needed `Clear()`) outputs between runs; seed state through input ports or component state, never by pre-loading outputs.

--- a/docs/wiki/701.-Export.md
+++ b/docs/wiki/701.-Export.md
@@ -1,5 +1,57 @@
 ## Exporting Your Mesh
+
 One of the great strengths of F-Mesh is its inherent traversability, making it straightforward to export the mesh into structured formats or visualize it as a graph.
 
-Here is the list of available formats and packages:
- - [DOT](https://github.com/hovsep/fmesh-graphviz) - allows exporting the fmesh in a form of DOT graph.
+Available formats and packages:
+ - [DOT](https://github.com/hovsep/fmesh-graphviz) — export the mesh as a Graphviz DOT graph.
+
+## Static graph
+
+```go
+import "github.com/hovsep/fmesh-graphviz/dot"
+
+exporter := dot.NewDotExporter()
+graph, err := exporter.Export(fm) // []byte of DOT source
+if err != nil {
+    // handle error
+}
+_ = os.WriteFile(fm.Name()+"-graph.dot", graph, 0o644)
+```
+
+Component and port names, descriptions (emoji work fine), and pipes all appear in the graph — a mesh built with meaningful descriptions is self-documenting when exported.
+
+View the result by pasting it into an online viewer such as [edotor.net](https://edotor.net), or render locally with Graphviz:
+
+```bash
+dot -Tsvg mesh-graph.dot -o mesh-graph.svg
+# batch-convert a directory of graphs:
+for f in *.dot; do dot -Tpng "$f" -o "${f%.dot}.png"; done
+```
+
+## Per-cycle graphs
+
+`ExportWithCycles` produces one graph per activation cycle, highlighting which components activated in each — a visual replay of the run:
+
+```go
+runtimeInfo, err := fm.Run()
+// ...
+cycleGraphs, err := exporter.ExportWithCycles(fm, runtimeInfo.Cycles)
+for cycleNum, graph := range cycleGraphs {
+    _ = os.WriteFile(fmt.Sprintf("cycle-%d.dot", cycleNum), graph, 0o644)
+}
+```
+
+See [Inspecting a run](https://github.com/hovsep/fmesh/wiki/402.-Inspecting-a-run) for what else `RuntimeInfo` holds. If a long run makes this expensive, cap the history with `WithCyclesHistoryLimit` — only retained cycles can be exported.
+
+## Tip: an export flag in your app
+
+Since the mesh is fully built before it runs, a cheap pattern is to gate export behind an environment variable or CLI flag: when set, the program builds the mesh, writes the graph, and exits without running. Handy for getting a topology picture of any mesh — build first, run only when asked:
+
+```go
+if os.Getenv("MESH_GRAPH") == "1" {
+    graph, _ := dot.NewDotExporter().Export(fm)
+    _ = os.WriteFile(fm.Name()+"-graph.dot", graph, 0o644)
+    return
+}
+_, err := fm.Run()
+```

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -31,6 +31,7 @@ F-Mesh follows semantic versioning. See [releases page](https://github.com/hovse
 | Inspecting a run | [402. Inspecting a run](https://github.com/hovsep/fmesh/wiki/402.-Inspecting-a-run) |
 | Hooks | [501. Hooks](https://github.com/hovsep/fmesh/wiki/501.-Hooks) |
 | Configuration & tips | [601. Tips & tricks](https://github.com/hovsep/fmesh/wiki/601.-Tips-&-tricks) |
+| Patterns & recipes | [602. Patterns & recipes](https://github.com/hovsep/fmesh/wiki/602.-Patterns-and-recipes) |
 | Export / visualization | [701. Export](https://github.com/hovsep/fmesh/wiki/701.-Export) |
 
 # API reference (user-facing packages)
@@ -45,4 +46,18 @@ The `cycle` package surfaces in the run-time report — see [402. Inspecting a r
 
 # Examples
 
-[fmesh-examples](https://github.com/hovsep/fmesh-examples) — including [nested meshes](https://github.com/hovsep/fmesh-examples/tree/main/nesting), pipelines, filters, and more.
+[fmesh-examples](https://github.com/hovsep/fmesh-examples) — runnable programs, from single-file demos to full applications. Highlights:
+
+- [pipeline](https://github.com/hovsep/fmesh-examples/tree/main/pipeline) — text-processing pipeline with a generic stage-chaining builder
+- [filter](https://github.com/hovsep/fmesh-examples/tree/main/filter) — label-based content routing
+- [fibonacci](https://github.com/hovsep/fmesh-examples/tree/main/fibonacci) — feedback-loop generator via loopback pipes
+- [electric_circuit](https://github.com/hovsep/fmesh-examples/tree/main/electric_circuit) — stateful two-component feedback loop with natural termination
+- [load_balancer](https://github.com/hovsep/fmesh-examples/tree/main/load_balancer) — round-robin dispatch/collect with indexed ports
+- [async_input](https://github.com/hovsep/fmesh-examples/tree/main/async_input) — driving a mesh from live external input (HTTP crawler)
+- [nesting](https://github.com/hovsep/fmesh-examples/tree/main/nesting) — a mesh running inside a component
+- [can_bus](https://github.com/hovsep/fmesh-examples/tree/main/can_bus) — broadcast bus topology; the advanced variant models a full CAN protocol stack
+- [simulation](https://github.com/hovsep/fmesh-examples/tree/main/simulation) — interactive REPL-driven step simulation harness
+- [life](https://github.com/hovsep/fmesh-examples/tree/main/life) — large tick-driven physiological simulation with nested meshes and a live TUI
+- [graphviz](https://github.com/hovsep/fmesh-examples/tree/main/graphviz) — static and per-cycle graph export
+
+The techniques these examples demonstrate are cataloged in [602. Patterns & recipes](https://github.com/hovsep/fmesh/wiki/602.-Patterns-and-recipes).


### PR DESCRIPTION
This pull request significantly expands the F-Mesh documentation with a new "Patterns & recipes" guide, deepens export/visualization instructions, and improves discoverability of both. It introduces practical, field-tested design patterns for building, running, and testing F-Mesh topologies, and links them directly to runnable example programs.

**Documentation improvements:**

* Added a comprehensive "Patterns & recipes" page (`602.-Patterns-and-recipes.md`) covering topology patterns, feedback loops, simulation techniques, large-mesh structuring, metadata usage, observation/testing patterns, and common gotchas.
* Updated the main wiki index (`Home.md`) to include the new patterns guide and to link to specific runnable examples in `fmesh-examples`, with descriptions of what each demonstrates. [[1]](diffhunk://#diff-139531db7965dbf04d8938e39e7de9e340ab889c5bdc96a0d38583972bd9f5c2R34) [[2]](diffhunk://#diff-139531db7965dbf04d8938e39e7de9e340ab889c5bdc96a0d38583972bd9f5c2L48-R63)
* Added a "Going further" section to the tips & tricks page, linking to the new patterns guide for advanced topics.

**Export/visualization enhancements:**

* Greatly expanded the export guide (`701.-Export.md`) with code samples for static and per-cycle DOT graph export, viewing options, and a recommended CLI flag pattern for on-demand export.

These changes make advanced F-Mesh usage more accessible, with practical recipes and richer example cross-references.