### PR TITLE
docs: publish a source-linked Go API reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Deploy API documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "1.26"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Build Sourcey documentation
+        env:
+          SOURCEY_SOURCE_REF: ${{ github.sha }}
+        run: |
+          npm install --no-save --package-lock=false sourcey@3.6.5
+          npx --no-install sourcey build --config sourcey.config.ts --output _site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ F-Mesh excels at:
 
 - **[Wiki](https://github.com/hovsep/fmesh/wiki)** - Full documentation (source lives in [`docs/wiki`](docs/wiki) — edit via PR, it is auto-synced to the wiki)
 - **[Examples Repository](https://github.com/hovsep/fmesh-examples)** - Working examples and patterns
+- **[Generated Go API](https://hovsep.github.io/fmesh/)** - Searchable, source-linked API reference
 - **[API Reference](https://pkg.go.dev/github.com/hovsep/fmesh)** - Complete API docs
 - **[Flow-Based Programming](https://jpaulm.github.io/fbp/)** - Learn about FBP (by J. Paul Morrison)
 ---

--- a/sourcey.config.ts
+++ b/sourcey.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, godoc } from "sourcey";
+
+export default defineConfig({
+  name: "F-Mesh",
+  siteUrl: "https://hovsep.github.io",
+  baseUrl: "/fmesh/",
+  repo: "https://github.com/hovsep/fmesh",
+  editBranch: process.env.SOURCEY_SOURCE_REF ?? "main",
+  logo: "./assets/img/logo.png",
+  theme: {
+    preset: "default",
+    colors: {
+      primary: "#2563eb",
+      light: "#60a5fa",
+      dark: "#1d4ed8",
+    },
+  },
+  navigation: {
+    tabs: [
+      {
+        tab: "Go API",
+        slug: "api",
+        source: godoc({
+          module: ".",
+          packages: ["./..."],
+          mode: "live",
+          includeTests: true,
+          includeUnexported: false,
+          hideUndocumented: false,
+        }),
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary

- add a Sourcey configuration for the module's public Go packages
- deploy the generated reference through the repository's existing GitHub
  Pages workflow target
- pin every generated source link to the exact commit that produced the site
- add a README link while keeping pkg.go.dev as the standard ecosystem view

## Why

The repository's canonical Pages URL currently returns 404 even though Pages is
configured for workflow deployment. This gives the project a searchable,
source-linked API reference at that existing project-owned URL without
committing generated HTML to `main`.

The generated reference covers all seven public packages and currently indexes
148 exported top-level declarations, including 55 exported types. It
complements the wiki and pkg.go.dev rather than replacing either one.

## Verification

- `make test` passes across the package and integration suites with Go 1.26.5
- `sourcey@3.6.5` builds 8 content pages successfully from a local, pinned CI
  install
- godoc extraction reports 7 packages, 148 exported top-level declarations,
  and zero diagnostics
- the generated search index contains 666 entries
- generated declaration links use `${{ github.sha }}` rather than a moving
  `main` URL

## Scope

No Go code or public API changes. The workflow runs only on `main` pushes or a
manual dispatch, and the generated `_site` directory exists only as a Pages
artifact. Sourcey is installed without a lockfile during the isolated CI job so
its TypeScript config can resolve the package it imports; no Node dependency is
added to the Go module.

If you prefer publishing under the existing `/projects/fmesh/` site instead of
the repository Pages URL, I can adjust the base URL and deployment handoff.