### PR TITLE
Add some gh docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo.
+* @hovsep

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
 name: Run tests and upload coverage
 
+# push on main only + pull_request: avoids double runs on PR branches while
+# still producing the required status check on fork PRs.
 on:
-  push
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Instead, use GitHub's private vulnerability reporting: go to the
+[Security tab](https://github.com/hovsep/fmesh/security) and click
+**"Report a vulnerability"**. This opens a private advisory visible only to the
+maintainer.
+
+You can expect an initial response within a week. Please include a description
+of the issue, steps to reproduce, and the affected version or commit if known.
+
+## Supported versions
+
+F-Mesh is under active development and not yet used in production. Security
+fixes land on `main` and are included in the next release; older releases are
+not patched.


### PR DESCRIPTION
This pull request introduces several improvements to repository management, workflow configuration, and security documentation. The most significant changes include the addition of a default code owner, refinement of CI workflow triggers to avoid redundant runs, and the introduction of a security policy.

Repository management:

* Added a default code owner (`@hovsep`) for all files in the repository by updating the `.github/CODEOWNERS` file.

Continuous integration workflow:

* Updated `.github/workflows/ci.yml` to trigger CI only on pushes to the `main` branch and on pull requests, preventing duplicate runs and ensuring required status checks for fork PRs.

Security:

* Added a `SECURITY.md` file outlining the security policy, including instructions for privately reporting vulnerabilities and information about supported versions.